### PR TITLE
Soutien Tipeee + uniformisation villes/prix (#23, #21, #22)

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "@/components/ThemeProvider";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useState } from "react";
-import { getDayOfWeek, getDateBlockColor, monthNamesShort, getDateParts, formatTimeDisplay, isToday } from "@/lib/utils";
+import { getDayOfWeek, getDateBlockColor, monthNamesShort, getDateParts, formatTimeDisplay, isToday, formatCityName, formatPrice } from "@/lib/utils";
 
 interface EventCardProps {
   event: Event;
@@ -20,7 +20,7 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
   const { day, month, year } = getDateParts(event);
 
   // Format location
-  const locationString = `${event.location_place || ''}${event.location_city ? ` — ${event.location_city}` : ''}${event.location_department ? ` (${event.location_department})` : ''}`;
+  const locationString = `${event.location_place || ''}${event.location_city ? ` — ${formatCityName(event.location_city)}` : ''}${event.location_department ? ` (${event.location_department})` : ''}`;
   
   const cardContent = (
     <div className="flex h-full">
@@ -104,7 +104,7 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
             <Euro className={`w-4 h-4 mr-1 ${
               theme === 'dark' ? 'brightness-0 invert' : 'brightness-0'
             }`} />
-            {event.price}
+            {formatPrice(event.price)}
           </div>
         )}
 

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -12,6 +12,7 @@ import { useDropzone } from "react-dropzone";
 import { X } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
+import { formatCityName, formatPrice } from "@/lib/utils";
 
 type Event = Database["public"]["Tables"]["events"]["Row"];
 type Theme = Database["public"]["Tables"]["themes"]["Row"];
@@ -240,8 +241,15 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
     
     // Nettoyer les erreurs si validation OK
     setValidationErrors({});
-    
-    await onSubmit(currentFormData);
+
+    // Uniformiser ville (majuscules) et prix (première lettre en majuscule) avant l'enregistrement
+    const normalizedFormData = {
+      ...currentFormData,
+      location_city: formatCityName(currentFormData.location_city),
+      price: currentFormData.price ? formatPrice(currentFormData.price) : currentFormData.price,
+    };
+
+    await onSubmit(normalizedFormData);
   };
 
   return (

--- a/src/components/EventProposalForm.tsx
+++ b/src/components/EventProposalForm.tsx
@@ -7,6 +7,7 @@ import { toast } from "@/hooks/use-toast";
 import { Card, CardContent } from "@/components/ui/card";
 import { supabase } from "@/integrations/supabase/client";
 import { useTheme } from "@/components/ThemeProvider";
+import { formatCityName, formatPrice } from "@/lib/utils";
 
 const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
   const { theme } = useTheme();
@@ -68,9 +69,9 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
       datetime: formData.datetime,
       end_time: formData.endTime || null,
       location_place: formData.location.place || null,
-      location_city: formData.location.city || null,
+      location_city: formData.location.city ? formatCityName(formData.location.city) : null,
       location_department: formData.location.department || null,
-      price: formData.price || null,
+      price: formData.price ? formatPrice(formData.price) : null,
       audience: formData.audience || null,
       url: formData.url || null,
       status: 'pending',

--- a/src/components/TipeeeSupport.tsx
+++ b/src/components/TipeeeSupport.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { Heart, X } from "lucide-react";
+import { useState } from "react";
+import { fetchTipeeeSettings } from "@/lib/siteSettings";
+import { useTheme } from "@/components/ThemeProvider";
+
+/**
+ * Widget de soutien Tipeee affiché sur le front lorsque l'option est activée
+ * dans l'administration. Deux rendus possibles selon la configuration :
+ *  - "button" : bouton flottant maison qui ouvre la page Tipeee dans un onglet
+ *  - "embed"  : widget embarqué dans une iframe, dépliable depuis un bouton flottant
+ */
+const TipeeeSupport = () => {
+  const { theme } = useTheme();
+  const [embedOpen, setEmbedOpen] = useState(false);
+
+  const { data: settings } = useQuery({
+    queryKey: ["site-settings", "tipeee"],
+    queryFn: fetchTipeeeSettings,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!settings?.enabled || !settings.url) return null;
+
+  const buttonClasses =
+    theme === "light"
+      ? "bg-[#fff7e6] text-[#1B263B] border-[#f3e0c7] hover:bg-[#ffe2b0] shadow-md"
+      : "bg-white/10 text-[#faf3ec] border-white/20 hover:bg-white/20 shadow-md";
+
+  if (settings.mode === "embed") {
+    return (
+      <div className="fixed bottom-6 left-6 z-40 flex flex-col items-start gap-2">
+        {embedOpen && (
+          <div className="relative w-[340px] max-w-[90vw] h-[480px] max-h-[70vh] rounded-lg overflow-hidden shadow-2xl border border-black/10 bg-white">
+            <button
+              type="button"
+              onClick={() => setEmbedOpen(false)}
+              aria-label="Fermer le soutien Tipeee"
+              className="absolute top-2 right-2 z-10 rounded-full bg-black/60 text-white p-1 hover:bg-black/80"
+            >
+              <X size={16} />
+            </button>
+            <iframe
+              src={settings.url}
+              title="Soutenir sur Tipeee"
+              className="w-full h-full border-0"
+              loading="lazy"
+            />
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setEmbedOpen((v) => !v)}
+          className={`flex items-center gap-2 px-4 py-2 rounded-full border font-medium transition-colors ${buttonClasses}`}
+        >
+          <Heart size={18} className="fill-current" />
+          Soutenir
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <a
+      href={settings.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`fixed bottom-6 left-6 z-40 flex items-center gap-2 px-4 py-2 rounded-full border font-medium transition-colors ${buttonClasses}`}
+    >
+      <Heart size={18} className="fill-current" />
+      Soutenir
+    </a>
+  );
+};
+
+export default TipeeeSupport;

--- a/src/components/settings/TipeeeSettingsCard.tsx
+++ b/src/components/settings/TipeeeSettingsCard.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import {
+  DEFAULT_TIPEEE_SETTINGS,
+  fetchTipeeeSettings,
+  saveTipeeeSettings,
+  type TipeeeMode,
+  type TipeeeSettings,
+} from "@/lib/siteSettings";
+
+/**
+ * Carte de configuration du widget de soutien Tipeee dans l'administration.
+ * Permet d'activer/désactiver le widget, de renseigner l'URL et de choisir
+ * entre un bouton flottant ou un widget embarqué.
+ */
+const TipeeeSettingsCard = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<TipeeeSettings>(DEFAULT_TIPEEE_SETTINGS);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["site-settings", "tipeee"],
+    queryFn: fetchTipeeeSettings,
+  });
+
+  // Synchroniser le formulaire avec les données chargées
+  useEffect(() => {
+    if (data) setForm(data);
+  }, [data]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const payload: TipeeeSettings = { ...form, url: form.url.trim() };
+      await saveTipeeeSettings(payload);
+      queryClient.invalidateQueries({ queryKey: ["site-settings", "tipeee"] });
+      toast({ title: "Configuration enregistrée", description: "Le widget de soutien a été mis à jour." });
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible d'enregistrer la configuration.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Soutien (Tipeee)</CardTitle>
+        <CardDescription>
+          Affichez un widget de soutien Tipeee sur la page d'accueil.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p>Chargement…</p>
+        ) : (
+          <div className="space-y-4 max-w-xl">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label htmlFor="tipeee-enabled">Activer le widget</Label>
+                <p className="text-sm text-muted-foreground">Affiche le bouton/widget de soutien sur le site.</p>
+              </div>
+              <Switch
+                id="tipeee-enabled"
+                checked={form.enabled}
+                onCheckedChange={(checked) => setForm((prev) => ({ ...prev, enabled: checked }))}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tipeee-url">URL Tipeee</Label>
+              <Input
+                id="tipeee-url"
+                type="url"
+                placeholder="https://fr.tipeee.com/mon-projet"
+                value={form.url}
+                onChange={(e) => setForm((prev) => ({ ...prev, url: e.target.value }))}
+              />
+              <p className="text-sm text-muted-foreground">
+                En mode « Widget embarqué », utilisez l'URL d'intégration fournie par Tipeee (la page doit autoriser l'affichage en iframe).
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tipeee-mode">Affichage</Label>
+              <Select
+                value={form.mode}
+                onValueChange={(value) => setForm((prev) => ({ ...prev, mode: value as TipeeeMode }))}
+              >
+                <SelectTrigger id="tipeee-mode" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="button">Bouton flottant</SelectItem>
+                  <SelectItem value="embed">Widget embarqué</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex justify-end">
+              <Button onClick={handleSave} disabled={isSaving}>
+                {isSaving ? "Enregistrement…" : "Enregistrer"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TipeeeSettingsCard;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -240,6 +240,24 @@ export type Database = {
         }
         Relationships: []
       }
+      site_settings: {
+        Row: {
+          key: string
+          updated_at: string
+          value: Json
+        }
+        Insert: {
+          key: string
+          updated_at?: string
+          value?: Json
+        }
+        Update: {
+          key?: string
+          updated_at?: string
+          value?: Json
+        }
+        Relationships: []
+      }
       themes: {
         Row: {
           created_at: string | null

--- a/src/lib/siteSettings.ts
+++ b/src/lib/siteSettings.ts
@@ -1,0 +1,58 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Json } from "@/integrations/supabase/types";
+
+/**
+ * Configuration du widget de soutien Tipeee, stockée dans la table
+ * `site_settings` sous la clé `tipeee` (colonne `value` en JSON).
+ */
+export type TipeeeMode = "button" | "embed";
+
+export interface TipeeeSettings {
+  /** Affiche ou non le widget sur le front */
+  enabled: boolean;
+  /** URL de la page / du widget Tipeee */
+  url: string;
+  /** Bouton flottant maison ou widget embarqué (iframe) */
+  mode: TipeeeMode;
+}
+
+export const TIPEEE_SETTINGS_KEY = "tipeee";
+
+export const DEFAULT_TIPEEE_SETTINGS: TipeeeSettings = {
+  enabled: false,
+  url: "",
+  mode: "button",
+};
+
+/** Normalise une valeur JSON inconnue en TipeeeSettings sûr. */
+export function parseTipeeeSettings(value: unknown): TipeeeSettings {
+  if (!value || typeof value !== "object") return { ...DEFAULT_TIPEEE_SETTINGS };
+  const v = value as Record<string, unknown>;
+  return {
+    enabled: typeof v.enabled === "boolean" ? v.enabled : DEFAULT_TIPEEE_SETTINGS.enabled,
+    url: typeof v.url === "string" ? v.url : DEFAULT_TIPEEE_SETTINGS.url,
+    mode: v.mode === "embed" ? "embed" : "button",
+  };
+}
+
+/** Récupère la config Tipeee (renvoie les valeurs par défaut si absente). */
+export async function fetchTipeeeSettings(): Promise<TipeeeSettings> {
+  const { data, error } = await supabase
+    .from("site_settings")
+    .select("value")
+    .eq("key", TIPEEE_SETTINGS_KEY)
+    .maybeSingle();
+  if (error) throw error;
+  return parseTipeeeSettings(data?.value);
+}
+
+/** Enregistre la config Tipeee (réservé aux super admins via RLS). */
+export async function saveTipeeeSettings(settings: TipeeeSettings): Promise<void> {
+  const { error } = await supabase
+    .from("site_settings")
+    .upsert(
+      { key: TIPEEE_SETTINGS_KEY, value: settings as unknown as Json, updated_at: new Date().toISOString() },
+      { onConflict: "key" }
+    );
+  if (error) throw error;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,26 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Normalise le nom d'une ville en majuscules (ex : "nantes" -> "NANTES").
+ * Utilisé à l'affichage et à la saisie pour uniformiser les villes.
+ */
+export function formatCityName(city?: string | null): string {
+  if (!city) return "";
+  return city.trim().toUpperCase();
+}
+
+/**
+ * Uniformise un texte de prix en mettant la première lettre en majuscule
+ * (ex : "gratuit" -> "Gratuit", "entrée libre" -> "Entrée libre").
+ */
+export function formatPrice(price?: string | null): string {
+  if (!price) return "";
+  const trimmed = price.trim();
+  if (!trimmed) return "";
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
 export const daysOfWeek = [
   "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"
 ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import BackToTop from "@/components/BackToTop";
+import TipeeeSupport from "@/components/TipeeeSupport";
 import EventList from "@/components/EventList";
 import EventProposalForm from "@/components/EventProposalForm";
 import { useTheme } from "@/components/ThemeProvider";
@@ -226,6 +227,9 @@ const Index = () => {
 
       {/* Add Back to Top button */}
       <BackToTop />
+
+      {/* Widget de soutien Tipeee (affiché si activé dans l'admin) */}
+      <TipeeeSupport />
     </div>
   );
 };

--- a/src/pages/SettingsAdmin.tsx
+++ b/src/pages/SettingsAdmin.tsx
@@ -11,6 +11,7 @@ import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader,
 import { AdminLayout } from "@/components/AdminLayout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
+import TipeeeSettingsCard from "@/components/settings/TipeeeSettingsCard";
 
 type Theme = Database["public"]["Tables"]["themes"]["Row"];
 type ThemeFormValues = {
@@ -402,6 +403,7 @@ const SettingsAdmin = () => {
                 </Dialog>
                 </CardContent>
             </Card>
+            <TipeeeSettingsCard />
         </div>
     </AdminLayout>
   );

--- a/supabase/migrations/20260617000000_site_settings.sql
+++ b/supabase/migrations/20260617000000_site_settings.sql
@@ -1,0 +1,29 @@
+-- Table de configuration globale du site (clé / valeur JSON).
+-- Lecture publique (front), écriture réservée aux super admins.
+create table if not exists public.site_settings (
+  key text primary key,
+  value jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.site_settings enable row level security;
+
+-- Lecture publique : nécessaire pour afficher le widget de soutien sur le front.
+drop policy if exists "site_settings_public_read" on public.site_settings;
+create policy "site_settings_public_read"
+  on public.site_settings
+  for select
+  using (true);
+
+-- Écriture (insert / update / delete) réservée aux super admins.
+drop policy if exists "site_settings_superadmin_write" on public.site_settings;
+create policy "site_settings_superadmin_write"
+  on public.site_settings
+  for all
+  using (public.is_super_admin(auth.uid()))
+  with check (public.is_super_admin(auth.uid()));
+
+-- Valeur par défaut pour le soutien Tipeee.
+insert into public.site_settings (key, value)
+values ('tipeee', '{"enabled": false, "url": "", "mode": "button"}'::jsonb)
+on conflict (key) do nothing;


### PR DESCRIPTION
## Résumé

Cette PR traite trois issues :

- **#23 — Soutien Tipeee** : widget de soutien configurable depuis l'admin.
- **#21 — Villes en majuscules**.
- **#22 — Uniformisation des textes de prix** (« Gratuit » et non « gratuit »…).

## Tipeee (#23)

- Nouvelle table `site_settings` (clé / valeur JSON) avec RLS : **lecture publique**, **écriture super-admin** (`is_super_admin(auth.uid())`).
- Carte de configuration dans **Paramètres** : activer/désactiver, URL Tipeee, et choix du mode d'affichage.
- Deux rendus au choix sur le front :
  - **Bouton flottant** maison (lien vers Tipeee)
  - **Widget embarqué** (iframe dépliable)
- Composant `TipeeeSupport` affiché sur la page d'accueil, masqué tant que l'option n'est pas activée.

## Villes & prix (#21, #22)

- Helpers partagés `formatCityName` (MAJUSCULES) et `formatPrice` (1ʳᵉ lettre en capitale) dans `lib/utils`.
- Appliqués **à l'affichage** (`EventCard`) **et à la saisie** (`EventForm`, `EventProposalForm`) pour des données propres en base.

## Vérifications

- `npm run build` : ✅
- `tsc` / `eslint` : aucune nouvelle erreur introduite (les erreurs restantes préexistent et concernent des fichiers non touchés).

Closes #23
Closes #21
Closes #22