### PR TITLE
Affiche la vraie date de dernière modification d'un événement

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -12,32 +12,36 @@ interface EventListProps {
   events: Event[];
   pastEvents?: Event[];
   onLoadPastEvents?: () => void;
+  lastUpdatedAt?: string | null;
 }
 
-const EventList = ({ events, pastEvents = [], onLoadPastEvents }: EventListProps) => {
+const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt }: EventListProps) => {
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([]);
   const [lastUpdated, setLastUpdated] = useState<string>("");
   const [isPastEventsOpen, setIsPastEventsOpen] = useState<boolean>(false);
   const { theme } = useTheme();
 
-  // Get formatted current date and time for "dernière mise à jour"
+  // Formate la date de la dernière création/modification d'un événement
   useEffect(() => {
-    if (!events || events.length === 0) {
+    if (!lastUpdatedAt) {
       setLastUpdated("");
       return;
     }
-    
-    // Use current date/time when the component loads or events change
-    // This reflects when the categorization of events (upcoming vs past) was last calculated
-    const now = new Date();
-    const dayName = daysOfWeek[now.getDay()];
-    const day = now.getDate();
-    const month = monthNames[now.getMonth()];
-    const year = now.getFullYear();
-    const hours = now.getHours().toString().padStart(2, '0');
-    const minutes = now.getMinutes().toString().padStart(2, '0');
+
+    const updated = new Date(lastUpdatedAt);
+    if (Number.isNaN(updated.getTime())) {
+      setLastUpdated("");
+      return;
+    }
+
+    const dayName = daysOfWeek[updated.getDay()];
+    const day = updated.getDate();
+    const month = monthNames[updated.getMonth()];
+    const year = updated.getFullYear();
+    const hours = updated.getHours().toString().padStart(2, '0');
+    const minutes = updated.getMinutes().toString().padStart(2, '0');
     setLastUpdated(`${dayName} ${day} ${month} ${year} à ${hours}h${minutes}`);
-  }, [events]);
+  }, [lastUpdatedAt]);
 
   // Filter events into upcoming based on the current date
   // Les événements passés sont maintenant passés directement en props

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,6 +22,7 @@ type Event = Database["public"]["Tables"]["events"]["Row"];
 const Index = () => {
   const [events, setEvents] = useState<Event[]>([]);
   const [pastEvents, setPastEvents] = useState<Event[]>([]);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const [isPastEventsLoaded, setIsPastEventsLoaded] = useState(false);
   const [isProposalDialogOpen, setIsProposalDialogOpen] = useState(false);
   const [isHeaderSticky, setIsHeaderSticky] = useState(false);
@@ -83,6 +84,30 @@ const Index = () => {
       }
 
       setEvents((data || []) as Event[]);
+
+      // Récupérer la date de dernière création/modification d'un événement
+      // (tous statuts confondus pour refléter l'activité réelle d'édition de l'agenda)
+      let lastUpdatedQuery = supabase
+        .from('events')
+        .select('updated_at')
+        .eq('status', 'accepted');
+
+      if (contextUser && !isSuperAdmin && organizations.length > 0) {
+        const userOrgIds = organizations.map(org => org.organization_id);
+        lastUpdatedQuery = lastUpdatedQuery.in('organization_id', userOrgIds);
+      }
+
+      lastUpdatedQuery = lastUpdatedQuery
+        .order('updated_at', { ascending: false, nullsFirst: false })
+        .limit(1);
+
+      const { data: lastUpdatedData, error: lastUpdatedError } = await lastUpdatedQuery;
+
+      if (lastUpdatedError) {
+        console.error('Erreur lors du chargement de la date de dernière mise à jour :', lastUpdatedError);
+      } else {
+        setLastUpdatedAt(lastUpdatedData?.[0]?.updated_at ?? null);
+      }
     };
     fetchEvents();
   }, [contextUser, isSuperAdmin, organizations, isLoading]);
@@ -204,7 +229,7 @@ const Index = () => {
 
       <main className={`flex-1 container mx-auto px-4 md:px-8 py-8 ${isHeaderSticky ? 'mt-48 md:mt-40' : ''}`}>
         <div className="max-w-4xl mx-auto">
-          <EventList events={events} pastEvents={pastEvents} onLoadPastEvents={fetchPastEvents} />
+          <EventList events={events} pastEvents={pastEvents} onLoadPastEvents={fetchPastEvents} lastUpdatedAt={lastUpdatedAt} />
         </div>
       </main>
 


### PR DESCRIPTION
## Contexte

Fixe #15 : l'indication « dernière mise à jour » affichait l'heure courante (`new Date()`) à chaque chargement de page, et non la date réelle de dernière création/modification d'un événement.

## Changements

**`src/pages/Index.tsx`**
- Nouvel état `lastUpdatedAt`.
- Requête dédiée récupérant le `updated_at` le plus récent parmi **tous** les événements acceptés (passés comme futurs), avec le même filtrage par organisation que le reste de la page (`order updated_at desc` + `limit 1`).
- Passage de `lastUpdatedAt` en prop à `EventList`.

**`src/components/EventList.tsx`**
- Nouvelle prop `lastUpdatedAt`, formatée pour l'affichage à la place de l'heure courante.

## Notes
- `events.updated_at` est renseigné à la création comme à la modification → couvre bien « dernière création / modification ».
- Le filtre `status = 'accepted'` reflète l'activité d'édition réellement visible sur l'agenda public.
- `tsc --noEmit` passe sans erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)