### PR TITLE
Filtres d'événements (département) extensibles

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -7,15 +7,25 @@ import { Share, Mail, MessageSquare, Send, ChevronDown, ChevronUp } from "lucide
 import { useTheme } from "@/components/ThemeProvider";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { getDayOfWeek, daysOfWeek, monthNames, monthNamesShort, getDateBlockColor } from "@/lib/utils";
+import EventFilters from "@/components/events/EventFilters";
+import type { FilterValues } from "@/lib/eventFilters";
 
 interface EventListProps {
   events: Event[];
   pastEvents?: Event[];
   onLoadPastEvents?: () => void;
   lastUpdatedAt?: string | null;
+  /** Options disponibles par filtre (chargées en amont, indépendamment des filtres actifs). */
+  filterOptions: Record<string, string[]>;
+  /** Valeurs de filtre courantes (portées par l'URL). */
+  filterValues: FilterValues;
+  /** Met à jour les filtres. */
+  onFilterChange: (values: FilterValues) => void;
+  /** Réinitialise les filtres. */
+  onFilterReset: () => void;
 }
 
-const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt }: EventListProps) => {
+const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, filterOptions, filterValues, onFilterChange, onFilterReset }: EventListProps) => {
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([]);
   const [lastUpdated, setLastUpdated] = useState<string>("");
   const [isPastEventsOpen, setIsPastEventsOpen] = useState<boolean>(false);
@@ -94,6 +104,8 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt }:
     return grouped;
   };
 
+  // Le filtrage est désormais effectué côté serveur (requête Supabase) :
+  // les listes reçues sont déjà filtrées.
   const groupedUpcomingEvents = groupEventsByMonthAndDay(upcomingEvents);
   const groupedPastEvents = groupEventsByMonthAndDay(pastEvents);
 
@@ -178,10 +190,24 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt }:
         </div>
       </div>
       
+      {/* Barre de filtres (extensible : voir src/lib/eventFilters.ts) */}
+      <EventFilters
+        options={filterOptions}
+        values={filterValues}
+        onChange={onFilterChange}
+        onReset={onFilterReset}
+      />
+
       {/* Upcoming Events Section */}
       <div className="space-y-8 mb-12">
         <h2 className={`text-2xl font-semibold mb-8 ${textColorClass}`}>Événements à venir</h2>
-        
+
+        {upcomingEvents.length === 0 && (
+          <p className={`opacity-70 ${textColorClass}`}>
+            Aucun événement à venir ne correspond à votre recherche.
+          </p>
+        )}
+
         {Object.entries(groupedUpcomingEvents).map(([month, dayEvents]) => (
           <div key={month} className="mb-12">
             {/* Month separator */}

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -1,0 +1,103 @@
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useTheme } from "@/components/ThemeProvider";
+import {
+  ALL_VALUE,
+  eventFilterDefinitions,
+  hasActiveFilters,
+  type FilterDefinition,
+  type FilterValues,
+} from "@/lib/eventFilters";
+import { X } from "lucide-react";
+
+interface EventFiltersProps {
+  /** Options disponibles par filtre (clé de filtre → valeurs), chargées en amont. */
+  options: Record<string, string[]>;
+  /** Valeurs de filtre courantes. */
+  values: FilterValues;
+  /** Appelé à chaque modification d'un filtre. */
+  onChange: (values: FilterValues) => void;
+  /** Réinitialise tous les filtres. */
+  onReset: () => void;
+  /** Liste des filtres à afficher (par défaut : tous les filtres connus). */
+  definitions?: FilterDefinition[];
+}
+
+const EventFilters = ({
+  options,
+  values,
+  onChange,
+  onReset,
+  definitions = eventFilterDefinitions,
+}: EventFiltersProps) => {
+  const { theme } = useTheme();
+  const isLight = theme === "light";
+
+  // On ne propose un filtre que s'il existe au moins deux valeurs distinctes :
+  // filtrer sur une unique valeur n'aurait aucun intérêt.
+  const filters = definitions
+    .map((definition) => ({
+      definition,
+      values: options[definition.key] ?? [],
+    }))
+    .filter(({ values: opts }) => opts.length >= 2);
+
+  if (filters.length === 0) return null;
+
+  const triggerClass = isLight
+    ? "border-[#f3e0c7] bg-white text-[#1B263B]"
+    : "border-white/20 bg-white/10 text-[#faf3ec]";
+  const labelClass = isLight ? "text-[#1B263B]" : "text-[#faf3ec]";
+
+  return (
+    <div className="mb-10 flex flex-wrap items-end gap-4">
+      {filters.map(({ definition, values: opts }) => (
+        <div key={definition.key} className="flex flex-col gap-1">
+          <span className={`text-sm font-medium ${labelClass}`}>
+            {definition.label}
+          </span>
+          <Select
+            value={values[definition.key] ?? ALL_VALUE}
+            onValueChange={(value) =>
+              onChange({ ...values, [definition.key]: value })
+            }
+          >
+            <SelectTrigger className={`w-[240px] ${triggerClass}`}>
+              <SelectValue placeholder={definition.allLabel} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_VALUE}>{definition.allLabel}</SelectItem>
+              {opts.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {definition.formatOption
+                    ? definition.formatOption(option)
+                    : option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ))}
+
+      {hasActiveFilters(values) && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          className={`gap-1 ${labelClass}`}
+        >
+          <X className="h-4 w-4" />
+          Réinitialiser
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default EventFilters;

--- a/src/lib/eventFilters.ts
+++ b/src/lib/eventFilters.ts
@@ -1,0 +1,115 @@
+/**
+ * Système de filtres générique et extensible pour la liste d'événements.
+ *
+ * Les filtres sont appliqués **côté serveur** (sur la requête Supabase) et leur
+ * état est porté par l'**URL** (query params), afin d'être partageables et
+ * compatibles avec la navigation arrière/avant.
+ *
+ * Pour ajouter un nouveau filtre (ville, public, prix, etc.), il suffit
+ * d'ajouter une `FilterDefinition` dans `eventFilterDefinitions` : l'UI
+ * (EventFilters), la lecture/écriture dans l'URL, le chargement des options et
+ * l'application sur la requête s'adaptent automatiquement.
+ */
+
+/** Valeur sentinelle représentant « aucun filtre » (tout afficher). */
+export const ALL_VALUE = "__all__";
+
+/** État des filtres : une valeur sélectionnée par clé de filtre. */
+export type FilterValues = Record<string, string>;
+
+export interface FilterDefinition {
+  /** Clé unique du filtre (utilisée dans l'état ET comme nom de query param). */
+  key: string;
+  /** Colonne de la table `events` sur laquelle filtrer / lister les options. */
+  column: string;
+  /** Libellé affiché au-dessus du contrôle. */
+  label: string;
+  /** Libellé de l'option « tout » (ex : « Tous les départements »). */
+  allLabel: string;
+  /** Met en forme l'affichage d'une option (par défaut : la valeur brute). */
+  formatOption?: (value: string) => string;
+  /** Ordonne les options (par défaut : ordre alphanumérique français). */
+  compareOptions?: (a: string, b: string) => number;
+}
+
+/** Noms des départements les plus fréquents (pour un affichage plus lisible). */
+const DEPARTMENT_NAMES: Record<string, string> = {
+  "44": "Loire-Atlantique",
+  "49": "Maine-et-Loire",
+  "85": "Vendée",
+  "79": "Deux-Sèvres",
+  "35": "Ille-et-Vilaine",
+  "56": "Morbihan",
+  "53": "Mayenne",
+  "72": "Sarthe",
+};
+
+/** Liste des filtres disponibles. Ajouter un filtre = ajouter une entrée ici. */
+export const eventFilterDefinitions: FilterDefinition[] = [
+  {
+    key: "department",
+    column: "location_department",
+    label: "Département",
+    allLabel: "Tous les départements",
+    formatOption: (value) =>
+      DEPARTMENT_NAMES[value] ? `${value} — ${DEPARTMENT_NAMES[value]}` : value,
+    compareOptions: (a, b) => a.localeCompare(b, "fr", { numeric: true }),
+  },
+];
+
+/** Tri par défaut des options d'un filtre. */
+export const sortFilterOptions = (
+  definition: FilterDefinition,
+  options: string[],
+): string[] => {
+  const compare =
+    definition.compareOptions ?? ((a, b) => a.localeCompare(b, "fr"));
+  return [...options].sort(compare);
+};
+
+/** Lit les valeurs de filtre depuis les query params de l'URL. */
+export const readFilterValues = (
+  params: URLSearchParams,
+  definitions: FilterDefinition[] = eventFilterDefinitions,
+): FilterValues =>
+  definitions.reduce<FilterValues>((acc, def) => {
+    acc[def.key] = params.get(def.key) ?? ALL_VALUE;
+    return acc;
+  }, {});
+
+/**
+ * Reporte les valeurs de filtre dans un objet de query params.
+ * Les filtres inactifs (« tout ») sont retirés de l'URL pour la garder propre.
+ */
+export const writeFilterParams = (
+  values: FilterValues,
+  definitions: FilterDefinition[] = eventFilterDefinitions,
+): Record<string, string> =>
+  definitions.reduce<Record<string, string>>((acc, def) => {
+    const value = values[def.key];
+    if (value && value !== ALL_VALUE) {
+      acc[def.key] = value;
+    }
+    return acc;
+  }, {});
+
+/**
+ * Applique les filtres actifs à une requête Supabase (PostgrestFilterBuilder).
+ * Typé de façon générique pour rester agnostique du type exact de la requête.
+ */
+export const applyFiltersToQuery = <T extends { eq: (column: string, value: string) => T }>(
+  query: T,
+  values: FilterValues,
+  definitions: FilterDefinition[] = eventFilterDefinitions,
+): T =>
+  definitions.reduce((q, def) => {
+    const selected = values[def.key];
+    if (selected && selected !== ALL_VALUE) {
+      return q.eq(def.column, selected);
+    }
+    return q;
+  }, query);
+
+/** Indique si au moins un filtre est actif (différent de « tout »). */
+export const hasActiveFilters = (values: FilterValues): boolean =>
+  Object.values(values).some((v) => v && v !== ALL_VALUE);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,9 +11,17 @@ import { supabase as baseSupabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
 import type { SupabaseClient, User } from '@supabase/supabase-js';
 import { Shield } from "lucide-react";
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
+import {
+  applyFiltersToQuery,
+  eventFilterDefinitions,
+  readFilterValues,
+  sortFilterOptions,
+  writeFilterParams,
+  type FilterValues,
+} from "@/lib/eventFilters";
 
 const supabase: SupabaseClient = baseSupabase;
 
@@ -27,8 +35,22 @@ const Index = () => {
   const [isProposalDialogOpen, setIsProposalDialogOpen] = useState(false);
   const [isHeaderSticky, setIsHeaderSticky] = useState(false);
   const [user, setUser] = useState<User | null>(null);
+  const [filterOptions, setFilterOptions] = useState<Record<string, string[]>>({});
+  const [searchParams, setSearchParams] = useSearchParams();
   const { theme } = useTheme();
   const { user: contextUser, isSuperAdmin, organizations, isLoading } = useUserRoleContext();
+
+  // Valeurs de filtre portées par l'URL (partageables, compatibles avec l'historique).
+  const filterValues = useMemo<FilterValues>(() => readFilterValues(searchParams), [searchParams]);
+  const filtersKey = JSON.stringify(filterValues);
+
+  const handleFilterChange = (values: FilterValues) => {
+    setSearchParams(writeFilterParams(values), { replace: true });
+  };
+
+  const handleFilterReset = () => {
+    setSearchParams({}, { replace: true });
+  };
 
   // Add scroll event listener to detect when to make the header sticky
   useEffect(() => {
@@ -71,6 +93,9 @@ const Index = () => {
         // Utilisateur non connecté : récupérer tous les événements publics
       }
 
+      // Appliquer les filtres actifs (département, etc.) côté serveur
+      futureQuery = applyFiltersToQuery(futureQuery, filterValues);
+
       // Trier les événements futurs par date croissante
       futureQuery = futureQuery
         .order('date', { nullsFirst: false })
@@ -110,7 +135,16 @@ const Index = () => {
       }
     };
     fetchEvents();
-  }, [contextUser, isSuperAdmin, organizations, isLoading]);
+    // filterValues est suivi via filtersKey (clé stable) pour éviter les rechargements liés à l'identité d'objet.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contextUser, isSuperAdmin, organizations, isLoading, filtersKey]);
+
+  // Les filtres étant appliqués côté serveur, un changement de filtre invalide
+  // les événements passés déjà chargés afin qu'ils soient rechargés filtrés.
+  useEffect(() => {
+    setPastEvents([]);
+    setIsPastEventsLoaded(false);
+  }, [filtersKey]);
 
   const fetchPastEvents = async () => {
     // Ne pas recharger si déjà chargé
@@ -136,6 +170,9 @@ const Index = () => {
       // Utilisateur non connecté : récupérer tous les événements publics
     }
 
+    // Appliquer les filtres actifs (département, etc.) côté serveur
+    pastQuery = applyFiltersToQuery(pastQuery, filterValues);
+
     // Trier les événements passés par date décroissante (les plus récents en premier)
     pastQuery = pastQuery
       .order('date', { ascending: false, nullsFirst: false })
@@ -152,6 +189,55 @@ const Index = () => {
     setPastEvents((data || []) as Event[]);
     setIsPastEventsLoaded(true);
   };
+
+  // Charge les options disponibles pour chaque filtre, indépendamment des
+  // filtres actifs (on respecte uniquement la visibilité par organisation), afin
+  // que la liste déroulante reste exhaustive même quand un filtre est appliqué.
+  useEffect(() => {
+    if (isLoading) return;
+
+    const fetchFilterOptions = async () => {
+      const userOrgIds =
+        contextUser && !isSuperAdmin && organizations.length > 0
+          ? organizations.map((org) => org.organization_id)
+          : null;
+
+      const entries = await Promise.all(
+        eventFilterDefinitions.map(async (definition) => {
+          let query = supabase
+            .from('events')
+            .select(definition.column)
+            .eq('status', 'accepted');
+
+          if (userOrgIds) {
+            query = query.in('organization_id', userOrgIds);
+          }
+
+          const { data, error } = await query;
+          if (error) {
+            console.error(`Erreur lors du chargement des options du filtre « ${definition.key} » :`, error);
+            return [definition.key, [] as string[]] as const;
+          }
+
+          const rows = (data || []) as Array<Record<string, string | null>>;
+          const values = Array.from(
+            new Set(
+              rows
+                .map((row) => row[definition.column])
+                .filter((value): value is string => value != null && String(value).trim() !== '')
+                .map((value) => String(value).trim()),
+            ),
+          );
+
+          return [definition.key, sortFilterOptions(definition, values)] as const;
+        }),
+      );
+
+      setFilterOptions(Object.fromEntries(entries));
+    };
+
+    fetchFilterOptions();
+  }, [contextUser, isSuperAdmin, organizations, isLoading]);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -229,7 +315,16 @@ const Index = () => {
 
       <main className={`flex-1 container mx-auto px-4 md:px-8 py-8 ${isHeaderSticky ? 'mt-48 md:mt-40' : ''}`}>
         <div className="max-w-4xl mx-auto">
-          <EventList events={events} pastEvents={pastEvents} onLoadPastEvents={fetchPastEvents} lastUpdatedAt={lastUpdatedAt} />
+          <EventList
+            events={events}
+            pastEvents={pastEvents}
+            onLoadPastEvents={fetchPastEvents}
+            lastUpdatedAt={lastUpdatedAt}
+            filterOptions={filterOptions}
+            filterValues={filterValues}
+            onFilterChange={handleFilterChange}
+            onFilterReset={handleFilterReset}
+          />
         </div>
       </main>
 


### PR DESCRIPTION
## Résumé

Implémente le système de filtres demandé dans #2, en commençant par le filtre **département**, avec une architecture pensée pour ajouter facilement d'autres filtres demain.

Le filtrage se fait **côté serveur** (requête Supabase) et l'état des filtres est porté par l'**URL** (query params), donc partageable et compatible avec la navigation arrière/avant.

## Changements

- **`src/lib/eventFilters.ts`** (nouveau) — registre déclaratif de filtres. Chaque filtre porte une `column` (colonne DB). Helpers génériques :
  - `readFilterValues` / `writeFilterParams` : synchronisation avec l'URL (les filtres inactifs sont retirés de l'URL)
  - `applyFiltersToQuery` : ajoute les `.eq(column, value)` à la requête pour chaque filtre actif
- **`src/components/events/EventFilters.tsx`** (nouveau) — barre de filtres générée à partir des définitions et des options reçues, avec bouton « Réinitialiser ».
- **`src/pages/Index.tsx`** — état des filtres via `useSearchParams`, filtres appliqués aux requêtes futurs/passés, et chargement séparé des options (en respectant la visibilité par organisation) pour que les listes déroulantes restent exhaustives.
- **`src/components/EventList.tsx`** — ne filtre plus côté client ; reçoit options, valeurs et callbacks.

## Extensibilité

Ajouter un filtre (ville, public, prix…) = **une entrée** dans `eventFilterDefinitions`. L'URL, la requête, le chargement des options et l'UI suivent automatiquement.

Closes #2
