### PR TITLE
Événements récurrents (création, gestion, affichage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 .yarn/
 
 yarn.lock
+
+# Supabase CLI
+supabase/.temp/

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,36 +1,87 @@
 import type { Database } from "@/integrations/supabase/types";
 type Event = Database["public"]["Tables"]["events"]["Row"];
 import { Card, CardContent } from "@/components/ui/card";
-import { ArrowRight, Euro, Ticket } from "lucide-react";
+import { ArrowRight, Euro, Ticket, Pencil, Repeat } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useUserRoleContext } from "@/components/UserRoleProvider";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import EventForm from "@/components/EventForm";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
 import { getDayOfWeek, getDateBlockColor, monthNamesShort, getDateParts, formatTimeDisplay, isToday, formatCityName, formatPrice } from "@/lib/utils";
+import { describeRecurrenceFromEvent } from "@/lib/recurrence";
 
 interface EventCardProps {
   event: Event;
   isPast?: boolean;
 }
 
-const EventCard = ({ event, isPast = false }: EventCardProps) => {
+const EventCard = ({ event: eventProp, isPast = false }: EventCardProps) => {
   const [openDialog, setOpenDialog] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+  // Copie locale de l'événement : permet de refléter une modification admin
+  // sans recharger la page (on reste exactement au même endroit).
+  const [event, setEvent] = useState(eventProp);
   const { theme } = useTheme();
+  const { toast } = useToast();
+  const { isSuperAdmin, isOrganizationAdmin } = useUserRoleContext();
+  const canEdit = isSuperAdmin || isOrganizationAdmin;
+
+  useEffect(() => {
+    setEvent(eventProp);
+  }, [eventProp]);
+
+  const handleSaveEvent = async (data: Partial<typeof event>): Promise<boolean> => {
+    // Nettoyer les données avant l'update (retirer la relation jointe et l'id,
+    // convertir les UUID vides en null).
+    const cleanData = { ...data } as Record<string, unknown>;
+    delete cleanData.theme;
+    delete cleanData.recurrence;
+    delete cleanData.id;
+    if (cleanData.organization_id === '') cleanData.organization_id = null;
+    if (cleanData.theme_id === '') cleanData.theme_id = null;
+
+    const updated = { ...cleanData, updated_at: new Date().toISOString() };
+    const { error } = await supabase.from('events').update(updated).eq('id', event.id);
+
+    if (error) {
+      toast({
+        title: "Erreur lors de la mise à jour",
+        description: error.message,
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    setEvent(prev => ({ ...prev, ...updated }) as typeof event);
+    toast({
+      title: "Événement mis à jour",
+      description: "L'événement a été mis à jour avec succès",
+    });
+    setShowEdit(false);
+    return true;
+  };
 
   const { day, month, year } = getDateParts(event);
+  const recurrenceLabel = describeRecurrenceFromEvent(event, { includeTime: false, withPrefix: false });
 
   // Format location
   const locationString = `${event.location_place || ''}${event.location_city ? ` — ${formatCityName(event.location_city)}` : ''}${event.location_department ? ` (${event.location_department})` : ''}`;
-  
+
   const cardContent = (
     <div className="flex h-full">
       {/* Date block à gauche */}
-      <div className={`${getDateBlockColor(event.date ? getDayOfWeek(event.date) : "lundi")} text-white flex flex-col items-center justify-center px-4 py-6 min-w-[120px] ${isPast ? 'opacity-60' : ''}`}>
+      <div className={`${getDateBlockColor(event.date ? getDayOfWeek(event.date) : "lundi")} text-white flex flex-col items-center justify-center px-4 py-6 w-[150px] flex-shrink-0 ${isPast ? 'opacity-60' : ''}`}>
         {isToday(event) ? (
           <>
             <div className="text-lg font-bold leading-none mb-1">Aujourd'hui</div>
             {formatTimeDisplay(event) && (
-              <div className="text-xs font-medium mt-2">à {formatTimeDisplay(event).replace(/\s*—.*/, '')}</div>
+              <>
+                <div className="w-8 border-t border-white/30 my-2"></div>
+                <div className="text-xs font-medium">{formatTimeDisplay(event)}</div>
+              </>
             )}
           </>
         ) : (
@@ -83,17 +134,60 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
 
       {/* Contenu principal */}
       <div className="flex-1 p-6 relative">
+        {/* Bouton Modifier (admins uniquement) */}
+        {canEdit && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={e => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setShowEdit(true);
+                }}
+                aria-label="Modifier l'événement"
+                className={`absolute top-4 right-4 z-10 p-2 rounded-full border transition-colors ${theme === 'dark'
+                    ? 'border-white/20 text-white/70 hover:text-white hover:bg-white/10'
+                    : 'border-gray-300 text-gray-600 hover:text-gray-800 hover:bg-gray-50'
+                  }`}
+              >
+                <Pencil className="w-4 h-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left" className="text-xs">
+              Modifier l'événement
+            </TooltipContent>
+          </Tooltip>
+        )}
+
+        {/* Dialog d'édition (admins) : s'ouvre sur place, la fermeture ne déplace pas la page */}
+        {canEdit && (
+          <Dialog open={showEdit} onOpenChange={setShowEdit}>
+            <DialogContent
+              className={`w-3/4 max-w-4xl mx-auto max-h-[90vh] overflow-y-auto ${theme === 'light' ? 'bg-[#f8f8f6] text-ephemeride border-none' : 'bg-ephemeride-light text-ephemeride-foreground border-none'}`}
+            >
+              <DialogHeader>
+                <DialogTitle>Modifier l'événement</DialogTitle>
+              </DialogHeader>
+              <EventForm
+                event={event}
+                onSave={handleSaveEvent}
+                onCancel={() => setShowEdit(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        )}
+
         {/* Nom de l'événement */}
-        <h3 className="text-xl font-bold mb-3 leading-tight">{event.name}</h3>
+        <h3 className={`text-xl font-bold mb-3 leading-tight ${canEdit ? 'pr-10' : ''}`}>{event.name}</h3>
 
         {/* Lieu */}
         <div className="flex items-center text-sm mb-2">
-          <img 
-            src="/lovable-uploads/680f536f-accd-4c50-8dd4-82707544fbe1.png" 
-            alt="Lieu" 
-            className={`w-4 h-4 mr-2 ${
-              theme === 'dark' ? 'brightness-0 invert' : 'brightness-0'
-            }`} 
+          <img
+            src="/lovable-uploads/680f536f-accd-4c50-8dd4-82707544fbe1.png"
+            alt="Lieu"
+            className={`w-4 h-4 mr-2 ${theme === 'dark' ? 'brightness-0 invert' : 'brightness-0'
+              }`}
           />
           {locationString}
         </div>
@@ -101,10 +195,17 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
         {/* Prix avec icône euro */}
         {!isPast && event.price && (
           <div className={`flex items-center text-sm mb-3 ${theme === 'dark' ? 'text-white/70' : 'text-gray-600'}`}>
-            <Euro className={`w-4 h-4 mr-1 ${
-              theme === 'dark' ? 'brightness-0 invert' : 'brightness-0'
-            }`} />
+            <Euro className={`w-4 h-4 mr-1 ${theme === 'dark' ? 'brightness-0 invert' : 'brightness-0'
+              }`} />
             {formatPrice(event.price)}
+          </div>
+        )}
+
+        {/* Récurrence avec icône (même style que le prix) */}
+        {recurrenceLabel && (
+          <div className={`flex items-center text-sm mb-3 ${theme === 'dark' ? 'text-white/70' : 'text-gray-600'}`}>
+            <Repeat className={`w-4 h-4 mr-1 shrink-0 ${theme === 'dark' ? 'brightness-0 invert' : 'brightness-0'}`} />
+            {recurrenceLabel}
           </div>
         )}
 
@@ -128,11 +229,10 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
                     rel="noopener noreferrer"
                     className="cursor-pointer"
                   >
-                    <Ticket className={`w-5 h-5 transition-transform hover:scale-110 ${
-                      theme === 'dark' 
-                        ? 'text-white/70 hover:text-white' 
+                    <Ticket className={`w-5 h-5 transition-transform hover:scale-110 ${theme === 'dark'
+                        ? 'text-white/70 hover:text-white'
                         : 'text-gray-600 hover:text-gray-800'
-                    }`} />
+                      }`} />
                   </a>
                 </TooltipTrigger>
                 <TooltipContent side="left" className="text-xs">
@@ -151,11 +251,10 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
                         href={event.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`px-4 py-2 text-xs font-medium border transition-colors ${
-                          theme === 'dark' 
-                            ? 'border-white/20 text-white hover:bg-white/10' 
+                        className={`px-4 py-2 text-xs font-medium border transition-colors ${theme === 'dark'
+                            ? 'border-white/20 text-white hover:bg-white/10'
                             : 'border-gray-300 text-gray-700 hover:bg-gray-50'
-                        }`}
+                          }`}
                       >
                         PLUS D'INFOS
                       </a>
@@ -173,11 +272,10 @@ const EventCard = ({ event, isPast = false }: EventCardProps) => {
                         rel="noopener noreferrer"
                         className="cursor-pointer"
                       >
-                        <ArrowRight className={`w-5 h-5 transition-transform hover:scale-110 ${
-                          theme === 'dark' 
-                            ? 'text-white/70 hover:text-white' 
+                        <ArrowRight className={`w-5 h-5 transition-transform hover:scale-110 ${theme === 'dark'
+                            ? 'text-white/70 hover:text-white'
                             : 'text-gray-600 hover:text-gray-800'
-                        }`} />
+                          }`} />
                       </a>
                     </TooltipTrigger>
                     <TooltipContent side="left" className="text-xs">

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -13,6 +13,9 @@ import { X } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
 import { formatCityName, formatPrice } from "@/lib/utils";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import RecurrenceFields from "@/components/RecurrenceFields";
+import type { RecurrenceRule, RecurringSharedFields } from "@/lib/recurrence";
 
 type Event = Database["public"]["Tables"]["events"]["Row"];
 type Theme = Database["public"]["Tables"]["themes"]["Row"];
@@ -43,7 +46,16 @@ interface EventFormProps {
   showValidationActions?: boolean;
   themes?: Theme[];
   theme?: 'light' | 'dark';
+  onSaveRecurring?: (rule: RecurrenceRule, shared: RecurringSharedFields) => Promise<boolean>;
 }
+
+const defaultRecurrence: RecurrenceRule = {
+  interval: 1,
+  weekdays: [],
+  startDate: '',
+  endDate: '',
+  startTime: '',
+};
 
 const defaultValues: EventFormValues = {
   id: '',
@@ -70,10 +82,14 @@ const fetchThemes = async (): Promise<Theme[]> => {
   return data as Theme[];
 };
 
-const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, theme: themeProp }: EventFormProps) => {
+const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, theme: themeProp, onSaveRecurring }: EventFormProps) => {
   const { toast } = useToast();
   const { currentOrganization, isSuperAdmin, organizations } = useUserRoleContext();
   const isEditing = !!event;
+  // Le mode récurrent n'est proposé qu'à la création (et si un handler est fourni).
+  const canRecur = !isEditing && !!onSaveRecurring;
+  const [eventType, setEventType] = useState<'single' | 'recurring'>('single');
+  const [recurrence, setRecurrence] = useState<RecurrenceRule>(defaultRecurrence);
   const [coverPreview, setCoverPreview] = useState<string | null>(event?.cover_url || null);
   const [coverFile, setCoverFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -133,53 +149,53 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
     disabled: isUploading,
   });
 
-  const onSubmit = async (data: Partial<Event>) => {
-    // La validation est maintenant faite par React Hook Form
+  // Upload l'affiche si une nouvelle a été déposée, sinon conserve l'URL existante.
+  // Retourne `undefined` en cas d'échec (l'appelant doit alors interrompre).
+  const uploadCoverIfNeeded = async (currentCoverUrl: string | null): Promise<string | null | undefined> => {
+    if (!coverFile) return currentCoverUrl;
+    setIsUploading(true);
+    const filePath = `covers/${Date.now()}_${coverFile.name}`;
+    const { error: uploadError } = await supabase.storage.from('event-assets').upload(filePath, coverFile, { upsert: true });
+    setIsUploading(false);
+    if (uploadError) {
+      toast({
+        title: "Erreur lors de l'upload de l'affiche",
+        description: uploadError.message,
+        variant: "destructive",
+      });
+      return undefined;
+    }
+    const { data: publicUrlData } = supabase.storage.from('event-assets').getPublicUrl(filePath);
+    setCoverPreview(publicUrlData.publicUrl);
+    return publicUrlData.publicUrl;
+  };
 
+  // Résout l'organisation à assigner selon le rôle de l'utilisateur.
+  const resolveOrganizationId = (selectedOrgId?: string | null): string | null => {
+    if (isSuperAdmin) {
+      return selectedOrgId && selectedOrgId !== 'none' ? selectedOrgId : null;
+    } else if (organizations.length > 1) {
+      return selectedOrgId && selectedOrgId !== 'none' ? selectedOrgId : null;
+    } else if (organizations.length === 1) {
+      return organizations[0].organization_id;
+    } else if (!isEditing && currentOrganization) {
+      return currentOrganization.organization_id;
+    }
+    return selectedOrgId ?? null;
+  };
+
+  const onSubmit = async (data: Partial<Event>) => {
     // Nettoyer les données : convertir les chaînes vides en null pour la base de données
     const cleanData = Object.fromEntries(
       Object.entries(data).map(([key, value]) => [
-        key, 
+        key,
         value === '' ? null : value
       ])
     ) as Partial<Event>;
-    let cover_url = cleanData.cover_url || null;
-    if (coverFile) {
-      setIsUploading(true);
-      const filePath = `covers/${Date.now()}_${coverFile.name}`;
-      const { error: uploadError } = await supabase.storage.from('event-assets').upload(filePath, coverFile, { upsert: true });
-      if (!uploadError) {
-        const { data: publicUrlData } = supabase.storage.from('event-assets').getPublicUrl(filePath);
-        cover_url = publicUrlData.publicUrl;
-        setCoverPreview(cover_url);
-      } else {
-        toast({
-          title: "Erreur lors de l'upload de l'affiche",
-          description: uploadError.message,
-          variant: "destructive",
-        });
-        setIsUploading(false);
-        return;
-      }
-      setIsUploading(false);
-    }
-    // Gestion de l'organization_id
-    let organization_id = cleanData.organization_id;
-    
-    if (isSuperAdmin) {
-      // Super admin : utiliser l'organisation sélectionnée dans le formulaire (peut être null)
-      organization_id = cleanData.organization_id && cleanData.organization_id !== 'none' ? cleanData.organization_id : null;
-    } else if (organizations.length > 1) {
-      // Utilisateur avec plusieurs organisations : utiliser la sélection du formulaire
-      organization_id = cleanData.organization_id && cleanData.organization_id !== 'none' ? cleanData.organization_id : null;
-    } else if (organizations.length === 1) {
-      // Utilisateur avec une seule organisation : assignation automatique
-      organization_id = organizations[0].organization_id;
-    } else if (!isEditing && currentOrganization) {
-      // Fallback : utiliser l'organisation courante
-      organization_id = currentOrganization.organization_id;
-    }
-    
+    const cover_url = await uploadCoverIfNeeded(cleanData.cover_url || null);
+    if (cover_url === undefined) return;
+    const organization_id = resolveOrganizationId(cleanData.organization_id);
+
     try {
       const success = await onSave({ ...cleanData, cover_url, organization_id });
       if (!success) {
@@ -196,12 +212,78 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
     }
   };
 
+  // Soumission d'un événement récurrent : valide la règle, prépare les champs
+  // partagés (upload affiche + organisation + normalisation) puis délègue la
+  // génération des occurrences au parent via onSaveRecurring.
+  const submitRecurring = async () => {
+    const currentFormData = formDataRef.current;
+    const fieldErrors: { [key: string]: string } = {};
+
+    if (!currentFormData.name?.trim()) fieldErrors.name = "Le nom de l'événement est obligatoire";
+    if (!currentFormData.location_city?.trim()) fieldErrors.location_city = "La ville est obligatoire";
+    if (!recurrence.startDate) fieldErrors.startDate = "La date de début est obligatoire";
+    if (!recurrence.endDate) fieldErrors.endDate = "La date de fin est obligatoire";
+    if (recurrence.startDate && recurrence.endDate && recurrence.endDate < recurrence.startDate) {
+      fieldErrors.endDate = "La date de fin doit être après la date de début";
+    }
+    if (!recurrence.startTime?.trim()) fieldErrors.startTime = "L'heure de début est obligatoire";
+    if (!recurrence.weekdays.length) fieldErrors.weekdays = "Sélectionnez au moins un jour";
+
+    if (Object.keys(fieldErrors).length > 0) {
+      setValidationErrors(fieldErrors);
+      toast({
+        title: "Champs obligatoires manquants",
+        description: "Veuillez compléter les informations de la récurrence.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setValidationErrors({});
+
+    const cover_url = await uploadCoverIfNeeded(currentFormData.cover_url || null);
+    if (cover_url === undefined) return;
+    const organization_id = resolveOrganizationId(currentFormData.organization_id);
+
+    const shared: RecurringSharedFields = {
+      name: currentFormData.name,
+      end_time: currentFormData.end_time || null,
+      location_place: currentFormData.location_place || null,
+      location_city: formatCityName(currentFormData.location_city),
+      location_department: currentFormData.location_department || null,
+      price: currentFormData.price ? formatPrice(currentFormData.price) : null,
+      audience: currentFormData.audience || null,
+      emoji: currentFormData.emoji || null,
+      url: currentFormData.url || null,
+      ticketing_url: currentFormData.ticketing_url || null,
+      theme_id: currentFormData.theme_id || null,
+      cover_url: cover_url || null,
+      organization_id,
+    };
+
+    try {
+      await onSaveRecurring?.(recurrence, shared);
+    } catch (e) {
+      console.error('💥 [EventForm] onSaveRecurring error', e);
+      toast({
+        title: "Erreur de sauvegarde",
+        description: "Une erreur est survenue lors de la création de la récurrence.",
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
+    // Événement récurrent : chemin de soumission dédié.
+    if (eventType === 'recurring') {
+      await submitRecurring();
+      return;
+    }
+
     // Récupérer les valeurs actuelles depuis la ref (plus fiable)
     const currentFormData = formDataRef.current;
-    
+
     // Validation manuelle simple
     const errors: string[] = [];
     const fieldErrors: {[key: string]: string} = {};
@@ -258,6 +340,25 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
         <Card className={theme === 'light' ? 'w-full md:w-3/4 bg-[#fff7e6] border-[#f3e0c7] text-[#1B263B] shadow-lg py-5' : 'w-full md:w-3/4 bg-ephemeride-light border-none text-ephemeride-foreground shadow-lg py-5'}>
           <CardContent>
             <div className="space-y-4">
+              {canRecur && (
+                <div className="space-y-2">
+                  <Label>Type d'événement</Label>
+                  <RadioGroup
+                    value={eventType}
+                    onValueChange={(value) => setEventType(value as 'single' | 'recurring')}
+                    className="flex flex-col sm:flex-row gap-4"
+                  >
+                    <label htmlFor="type-single" className="flex items-center gap-2 cursor-pointer">
+                      <RadioGroupItem id="type-single" value="single" />
+                      <span>Événement ponctuel</span>
+                    </label>
+                    <label htmlFor="type-recurring" className="flex items-center gap-2 cursor-pointer">
+                      <RadioGroupItem id="type-recurring" value="recurring" />
+                      <span>Événement récurrent</span>
+                    </label>
+                  </RadioGroup>
+                </div>
+              )}
               <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <div className="space-y-2 md:col-span-3">
                   <Label htmlFor="name">Nom de l'événement *</Label>
@@ -341,48 +442,59 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
                 </div>
               )}
 
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="datetime">Date et heure *</Label>
-                  <Input
-                    id="datetime"
-                    value={formData.datetime || ''}
-                    onChange={(e) => setFormData(prev => ({ ...prev, datetime: e.target.value }))}
-                    placeholder="ex: mercredi 21 mai 2025 à 16h30"
-                    className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.datetime ? 'border-red-500 focus:border-red-500' : ''}`}
-                  />
-                  {validationErrors.datetime ? (
-                    <p className="text-red-500 text-sm">{validationErrors.datetime}</p>
-                  ) : (
-                    <p className="text-xs text-white/60">Format : jour date mois année à/de heure</p>
-                  )}
+              {eventType === 'recurring' ? (
+                <RecurrenceFields
+                  value={recurrence}
+                  onChange={setRecurrence}
+                  endTime={formData.end_time || ''}
+                  onEndTimeChange={(value) => setFormData(prev => ({ ...prev, end_time: value }))}
+                  theme={theme}
+                  errors={validationErrors}
+                />
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="datetime">Date et heure *</Label>
+                    <Input
+                      id="datetime"
+                      value={formData.datetime || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, datetime: e.target.value }))}
+                      placeholder="ex: mercredi 21 mai 2025 à 16h30"
+                      className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.datetime ? 'border-red-500 focus:border-red-500' : ''}`}
+                    />
+                    {validationErrors.datetime ? (
+                      <p className="text-red-500 text-sm">{validationErrors.datetime}</p>
+                    ) : (
+                      <p className="text-xs text-white/60">Format : jour date mois année à/de heure</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="date">Date réelle *</Label>
+                    <Input
+                      id="date"
+                      type="date"
+                      value={formData.date || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, date: e.target.value }))}
+                      className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.date ? 'border-red-500 focus:border-red-500' : ''}`}
+                    />
+                    {validationErrors.date ? (
+                      <p className="text-red-500 text-sm">{validationErrors.date}</p>
+                    ) : (
+                      <p className="text-xs text-white/60">Permet un tri fiable par date</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="end_time">Heure de fin (optionnel)</Label>
+                    <Input
+                      id="end_time"
+                      value={formData.end_time || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, end_time: e.target.value }))}
+                      placeholder="ex: 19h00"
+                      className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'}
+                    />
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="date">Date réelle *</Label>
-                  <Input
-                    id="date"
-                    type="date"
-                    value={formData.date || ''}
-                    onChange={(e) => setFormData(prev => ({ ...prev, date: e.target.value }))}
-                    className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.date ? 'border-red-500 focus:border-red-500' : ''}`}
-                  />
-                  {validationErrors.date ? (
-                    <p className="text-red-500 text-sm">{validationErrors.date}</p>
-                  ) : (
-                    <p className="text-xs text-white/60">Permet un tri fiable par date</p>
-                  )}
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="end_time">Heure de fin (optionnel)</Label>
-                  <Input
-                    id="end_time"
-                    value={formData.end_time || ''}
-                    onChange={(e) => setFormData(prev => ({ ...prev, end_time: e.target.value }))}
-                    placeholder="ex: 19h00"
-                    className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'}
-                  />
-                </div>
-              </div>
+              )}
 
               <div className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -556,7 +668,7 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
               className={theme === 'light' ? 'bg-[#fff7e6] text-[#1B263B] border-[#f3e0c7] hover:bg-[#ffe2b0] shadow-sm' : 'bg-white text-ephemeride hover:bg-white/80'}
               disabled={false}
             >
-              {isEditing ? "Mettre à jour" : "Créer l'événement"}
+              {isEditing ? "Mettre à jour" : eventType === 'recurring' ? "Créer les événements" : "Créer l'événement"}
             </Button>
           )}
         </div>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -39,14 +39,26 @@ type EventFormValues = {
   organization_id?: string | null;
 };
 
+// Règle de récurrence telle que jointe depuis la table event_recurrences.
+type JoinedRecurrence = {
+  interval: number;
+  weekdays: number[];
+  start_date: string;
+  end_date: string;
+} | null;
+
+type EventFormEvent = Partial<Event> & { recurrence?: JoinedRecurrence };
+
 interface EventFormProps {
-  event?: Partial<Event>;
+  event?: EventFormEvent;
   onSave: (event: Partial<Event>) => Promise<boolean>;
   onCancel: () => void;
   showValidationActions?: boolean;
   themes?: Theme[];
   theme?: 'light' | 'dark';
   onSaveRecurring?: (rule: RecurrenceRule, shared: RecurringSharedFields) => Promise<boolean>;
+  // Mode duplication : pré-remplit le formulaire mais reste en création.
+  duplicate?: boolean;
 }
 
 const defaultRecurrence: RecurrenceRule = {
@@ -82,10 +94,11 @@ const fetchThemes = async (): Promise<Theme[]> => {
   return data as Theme[];
 };
 
-const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, theme: themeProp, onSaveRecurring }: EventFormProps) => {
+const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, theme: themeProp, onSaveRecurring, duplicate }: EventFormProps) => {
   const { toast } = useToast();
   const { currentOrganization, isSuperAdmin, organizations } = useUserRoleContext();
-  const isEditing = !!event;
+  // En duplication, on pré-remplit depuis un événement source mais on reste en création.
+  const isEditing = !!event && !duplicate;
   // Le mode récurrent n'est proposé qu'à la création (et si un handler est fourni).
   const canRecur = !isEditing && !!onSaveRecurring;
   const [eventType, setEventType] = useState<'single' | 'recurring'>('single');
@@ -104,29 +117,55 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
     formDataRef.current = formData;
   }, [formData]);
 
-  // Remplir le formulaire si édition
+  // Remplir le formulaire si édition / duplication
   useEffect(() => {
     if (event) {
-      // Convertir les valeurs null en chaînes vides pour éviter les warnings React
+      // Convertir les valeurs null en chaînes vides pour éviter les warnings React.
+      // On écarte les champs joints (theme, recurrence) qui ne sont pas des colonnes.
       const sanitizedEvent = Object.fromEntries(
-        Object.entries(event).map(([key, value]) => [
-          key, 
-          value === null ? '' : value
-        ])
+        Object.entries(event)
+          .filter(([key]) => !['recurrence', 'theme'].includes(key))
+          .map(([key, value]) => [
+            key,
+            value === null ? '' : value
+          ])
       );
-      
+
       const newValues = {
         ...defaultValues,
         ...sanitizedEvent,
       };
-      
+
+      // En duplication : on crée un nouvel événement, donc pas d'id ni de lien
+      // de récurrence hérités.
+      if (duplicate) {
+        newValues.id = '';
+        newValues.recurrence_id = null;
+      }
+
       setFormData(newValues);
       formDataRef.current = newValues;
+
+      // Duplication d'un événement récurrent : pré-remplir la récurrence.
+      if (duplicate && event.recurrence) {
+        const startTime = event.datetime?.match(/\d{1,2}h\d{2}/)?.[0] ?? '';
+        setEventType('recurring');
+        setRecurrence({
+          interval: event.recurrence.interval,
+          weekdays: event.recurrence.weekdays,
+          startDate: event.recurrence.start_date,
+          endDate: event.recurrence.end_date,
+          startTime,
+        });
+      } else {
+        setEventType('single');
+        setRecurrence(defaultRecurrence);
+      }
     } else {
       setFormData(defaultValues);
       formDataRef.current = defaultValues;
     }
-  }, [event]);
+  }, [event, duplicate]);
 
   const { data: themesData, isLoading: isLoadingThemes } = useQuery<Theme[]>({
     queryKey: ["themes"],

--- a/src/components/EventProposalForm.tsx
+++ b/src/components/EventProposalForm.tsx
@@ -8,9 +8,22 @@ import { Card, CardContent } from "@/components/ui/card";
 import { supabase } from "@/integrations/supabase/client";
 import { useTheme } from "@/components/ThemeProvider";
 import { formatCityName, formatPrice } from "@/lib/utils";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import RecurrenceFields from "@/components/RecurrenceFields";
+import { buildRecurringEvents, type RecurrenceRule } from "@/lib/recurrence";
+
+const defaultRecurrence: RecurrenceRule = {
+  interval: 1,
+  weekdays: [],
+  startDate: "",
+  endDate: "",
+  startTime: "",
+};
 
 const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
   const { theme } = useTheme();
+  const [eventType, setEventType] = useState<"single" | "recurring">("single");
+  const [recurrence, setRecurrence] = useState<RecurrenceRule>(defaultRecurrence);
   const [formData, setFormData] = useState({
     name: "",
     datetime: "",
@@ -50,10 +63,101 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
     }
   };
 
+  // Champs partagés par toutes les occurrences (et utilisés en mode ponctuel).
+  const buildSharedFields = () => ({
+    name: formData.name,
+    end_time: formData.endTime || null,
+    location_place: formData.location.place || null,
+    location_city: formData.location.city ? formatCityName(formData.location.city) : null,
+    location_department: formData.location.department || null,
+    price: formData.price ? formatPrice(formData.price) : null,
+    audience: formData.audience || null,
+    url: formData.url || null,
+  });
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    // Validate form
+
+    const createdby = { name: formData.proposerName, email: formData.proposerEmail };
+
+    if (eventType === "recurring") {
+      // Validation de la récurrence
+      if (
+        !formData.name ||
+        !recurrence.startDate ||
+        !recurrence.endDate ||
+        !recurrence.startTime ||
+        !recurrence.weekdays.length ||
+        recurrence.endDate < recurrence.startDate
+      ) {
+        toast({
+          title: "Informations manquantes",
+          description: "Veuillez compléter le nom et les informations de récurrence (dates, heure, jours).",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const occurrences = buildRecurringEvents(recurrence, buildSharedFields());
+      if (occurrences.length === 0) {
+        toast({
+          title: "Aucune occurrence",
+          description: "La récurrence ne génère aucun événement sur la période choisie.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      // 1. Créer la règle de récurrence.
+      const { data: recurrenceData, error: recurrenceError } = await supabase
+        .from("event_recurrences")
+        .insert({
+          frequency: "weekly",
+          interval: recurrence.interval,
+          weekdays: recurrence.weekdays,
+          start_date: recurrence.startDate,
+          end_date: recurrence.endDate,
+        })
+        .select()
+        .single();
+
+      if (recurrenceError || !recurrenceData) {
+        toast({
+          title: "Erreur lors de la proposition",
+          description: recurrenceError?.message ?? "Erreur inconnue",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      // 2. Insérer les occurrences en attente, liées à la récurrence.
+      const rows = occurrences.map((occ) => ({
+        ...occ,
+        status: "pending",
+        createdby,
+        recurrence_id: recurrenceData.id,
+      }));
+      const { error: insertError } = await supabase.from("events").insert(rows);
+
+      if (insertError) {
+        await supabase.from("event_recurrences").delete().eq("id", recurrenceData.id);
+        toast({
+          title: "Erreur lors de la proposition",
+          description: insertError.message,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      toast({
+        title: "Proposition envoyée !",
+        description: `${rows.length} occurrences proposées. Merci pour votre contribution !`,
+      });
+      onClose();
+      return;
+    }
+
+    // Mode ponctuel
     if (!formData.name || !formData.datetime) {
       toast({
         title: "Informations manquantes",
@@ -63,19 +167,11 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
       return;
     }
 
-    // Insertion dans Supabase avec statut 'pending' et createdby
-    const { error } = await supabase.from('events').insert({
-      name: formData.name,
+    const { error } = await supabase.from("events").insert({
+      ...buildSharedFields(),
       datetime: formData.datetime,
-      end_time: formData.endTime || null,
-      location_place: formData.location.place || null,
-      location_city: formData.location.city ? formatCityName(formData.location.city) : null,
-      location_department: formData.location.department || null,
-      price: formData.price ? formatPrice(formData.price) : null,
-      audience: formData.audience || null,
-      url: formData.url || null,
-      status: 'pending',
-      createdby: { name: formData.proposerName, email: formData.proposerEmail },
+      status: "pending",
+      createdby,
     });
     if (error) {
       toast({
@@ -85,14 +181,11 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
       });
       return;
     }
-    
-    // Show success message
+
     toast({
       title: "Proposition envoyée !",
       description: "Merci pour votre contribution à l'agenda culturel",
     });
-    
-    // Close modal
     onClose();
   };
 
@@ -102,8 +195,25 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
       <Card className={theme === 'light' ? 'border-[#f3e0c7] bg-[#fff7e6]' : 'border-white/20 bg-ephemeride-light/50'}>
         <CardContent className="pt-6">
           <h3 className={theme === 'light' ? 'text-[#1B263B] text-lg font-medium mb-4' : 'text-[#faf3ec] text-lg font-medium mb-4'}>Informations générales</h3>
-          
+
           <div className="space-y-4">
+            <div>
+              <Label className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Type d'événement</Label>
+              <RadioGroup
+                value={eventType}
+                onValueChange={(value) => setEventType(value as 'single' | 'recurring')}
+                className="flex flex-col sm:flex-row gap-4 mt-1"
+              >
+                <label htmlFor="proposal-type-single" className={`flex items-center gap-2 cursor-pointer ${theme === 'light' ? 'text-[#1B263B]' : 'text-white'}`}>
+                  <RadioGroupItem id="proposal-type-single" value="single" />
+                  <span>Événement ponctuel</span>
+                </label>
+                <label htmlFor="proposal-type-recurring" className={`flex items-center gap-2 cursor-pointer ${theme === 'light' ? 'text-[#1B263B]' : 'text-white'}`}>
+                  <RadioGroupItem id="proposal-type-recurring" value="recurring" />
+                  <span>Événement récurrent</span>
+                </label>
+              </RadioGroup>
+            </div>
             <div>
               <Label htmlFor="name" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Nom de l'événement *</Label>
               <Input
@@ -117,31 +227,43 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
               />
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="datetime" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Date et heure *</Label>
-                <Input
-                  id="datetime"
-                  name="datetime"
-                  required
-                  placeholder="ex: mercredi 21 mai 2025 à 16h30"
-                  value={formData.datetime}
-                  onChange={handleChange}
-                  className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}
+            {eventType === 'recurring' ? (
+              <div className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>
+                <RecurrenceFields
+                  value={recurrence}
+                  onChange={setRecurrence}
+                  endTime={formData.endTime}
+                  onEndTimeChange={(value) => setFormData(prev => ({ ...prev, endTime: value }))}
+                  theme={theme}
                 />
               </div>
-              <div>
-                <Label htmlFor="endTime" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Heure de fin (optionnel)</Label>
-                <Input
-                  id="endTime"
-                  name="endTime"
-                  placeholder="ex: 19h00"
-                  value={formData.endTime}
-                  onChange={handleChange}
-                  className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}
-                />
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="datetime" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Date et heure *</Label>
+                  <Input
+                    id="datetime"
+                    name="datetime"
+                    required
+                    placeholder="ex: mercredi 21 mai 2025 à 16h30"
+                    value={formData.datetime}
+                    onChange={handleChange}
+                    className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="endTime" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Heure de fin (optionnel)</Label>
+                  <Input
+                    id="endTime"
+                    name="endTime"
+                    placeholder="ex: 19h00"
+                    value={formData.endTime}
+                    onChange={handleChange}
+                    className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}
+                  />
+                </div>
               </div>
-            </div>
+            )}
             <div>
               <Label htmlFor="url" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Lien externe (optionnel)</Label>
               <Input

--- a/src/components/RecurrenceFields.tsx
+++ b/src/components/RecurrenceFields.tsx
@@ -1,0 +1,144 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { RecurrenceRule } from "@/lib/recurrence";
+
+// Jours dans l'ordre français (lundi → dimanche), mappés sur les valeurs JS getDay().
+const WEEKDAYS: { label: string; value: number }[] = [
+  { label: "L", value: 1 },
+  { label: "M", value: 2 },
+  { label: "M", value: 3 },
+  { label: "J", value: 4 },
+  { label: "V", value: 5 },
+  { label: "S", value: 6 },
+  { label: "D", value: 0 },
+];
+
+interface RecurrenceFieldsProps {
+  value: RecurrenceRule;
+  onChange: (value: RecurrenceRule) => void;
+  endTime: string;
+  onEndTimeChange: (value: string) => void;
+  theme?: "light" | "dark";
+  errors?: { [key: string]: string };
+}
+
+const RecurrenceFields = ({
+  value,
+  onChange,
+  endTime,
+  onEndTimeChange,
+  theme = "dark",
+  errors = {},
+}: RecurrenceFieldsProps) => {
+  const inputClass =
+    theme === "light"
+      ? "border-[#f3e0c7] bg-white text-[#1B263B]"
+      : "border-white/20 bg-white/10 text-white";
+
+  const update = (patch: Partial<RecurrenceRule>) => {
+    onChange({ ...value, ...patch });
+  };
+
+  // Radix ToggleGroup (type="multiple") travaille avec des strings.
+  const selectedStrings = value.weekdays.map(String);
+  const handleWeekdaysChange = (next: string[]) => {
+    update({ weekdays: next.map((s) => parseInt(s, 10)) });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="recurrence_start">Date de début *</Label>
+          <Input
+            id="recurrence_start"
+            type="date"
+            value={value.startDate || ""}
+            onChange={(e) => update({ startDate: e.target.value })}
+            className={`${inputClass} ${errors.startDate ? "border-red-500 focus:border-red-500" : ""}`}
+          />
+          {errors.startDate && <p className="text-red-500 text-sm">{errors.startDate}</p>}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="recurrence_end">Date de fin *</Label>
+          <Input
+            id="recurrence_end"
+            type="date"
+            value={value.endDate || ""}
+            onChange={(e) => update({ endDate: e.target.value })}
+            className={`${inputClass} ${errors.endDate ? "border-red-500 focus:border-red-500" : ""}`}
+          />
+          {errors.endDate && <p className="text-red-500 text-sm">{errors.endDate}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="recurrence_start_time">Heure de début *</Label>
+          <Input
+            id="recurrence_start_time"
+            value={value.startTime || ""}
+            onChange={(e) => update({ startTime: e.target.value })}
+            placeholder="ex: 14h00"
+            className={`${inputClass} ${errors.startTime ? "border-red-500 focus:border-red-500" : ""}`}
+          />
+          {errors.startTime && <p className="text-red-500 text-sm">{errors.startTime}</p>}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="recurrence_end_time">Heure de fin (optionnel)</Label>
+          <Input
+            id="recurrence_end_time"
+            value={endTime || ""}
+            onChange={(e) => onEndTimeChange(e.target.value)}
+            placeholder="ex: 19h00"
+            className={inputClass}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="recurrence_interval">Rythme *</Label>
+          <div className="flex items-center gap-2">
+            <span className="text-sm whitespace-nowrap">Toutes les</span>
+            <Input
+              id="recurrence_interval"
+              type="number"
+              min={1}
+              value={value.interval || 1}
+              onChange={(e) => update({ interval: Math.max(1, parseInt(e.target.value, 10) || 1) })}
+              className={`${inputClass} w-16`}
+            />
+            <span className="text-sm whitespace-nowrap">semaine(s)</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Jours de récurrence *</Label>
+        <ToggleGroup
+          type="multiple"
+          value={selectedStrings}
+          onValueChange={handleWeekdaysChange}
+          className="justify-start flex-wrap"
+        >
+          {WEEKDAYS.map((day, index) => (
+            <ToggleGroupItem
+              key={`${day.value}-${index}`}
+              value={String(day.value)}
+              aria-label={`Jour ${day.label}`}
+              className={
+                theme === "light"
+                  ? "h-10 w-10 border border-[#f3e0c7] data-[state=on]:bg-[#1B263B] data-[state=on]:text-white"
+                  : "h-10 w-10 border border-white/20 text-white data-[state=on]:bg-white data-[state=on]:text-ephemeride"
+              }
+            >
+              {day.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+        {errors.weekdays && <p className="text-red-500 text-sm">{errors.weekdays}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default RecurrenceFields;

--- a/src/components/TipeeeSupport.tsx
+++ b/src/components/TipeeeSupport.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Heart, X } from "lucide-react";
+import { HandHeart, X } from "lucide-react";
 import { useState } from "react";
 import { fetchTipeeeSettings } from "@/lib/siteSettings";
 import { useTheme } from "@/components/ThemeProvider";
@@ -53,8 +53,8 @@ const TipeeeSupport = () => {
           onClick={() => setEmbedOpen((v) => !v)}
           className={`flex items-center gap-2 px-4 py-2 rounded-full border font-medium transition-colors ${buttonClasses}`}
         >
-          <Heart size={18} className="fill-current" />
-          Soutenir
+          <HandHeart size={18} className="fill-current" />
+          Soutenez-nous sur Tipeee
         </button>
       </div>
     );
@@ -67,8 +67,8 @@ const TipeeeSupport = () => {
       rel="noopener noreferrer"
       className={`fixed bottom-6 left-6 z-40 flex items-center gap-2 px-4 py-2 rounded-full border font-medium transition-colors ${buttonClasses}`}
     >
-      <Heart size={18} className="fill-current" />
-      Soutenir
+      <HandHeart size={18} className="fill-current" />
+      Soutenez-nous sur Tipeee
     </a>
   );
 };

--- a/src/components/events/EventsTable.tsx
+++ b/src/components/events/EventsTable.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Edit, Trash, Repeat } from "lucide-react";
+import { Edit, Trash, Repeat, Copy } from "lucide-react";
 import { describeRecurrenceFromEvent } from "@/lib/recurrence";
 
 interface EventsTableProps {
@@ -12,9 +12,10 @@ interface EventsTableProps {
   onEdit: (event: Event) => void;
   onDelete: (id: string) => void;
   onDeleteSeries?: (event: Event) => void;
+  onDuplicate?: (event: Event) => void;
 }
 
-const EventsTable = ({ events, onEdit, onDelete, onDeleteSeries }: EventsTableProps) => (
+const EventsTable = ({ events, onEdit, onDelete, onDeleteSeries, onDuplicate }: EventsTableProps) => (
   <Card>
     <CardContent className="p-6">
       <Table>
@@ -63,6 +64,16 @@ const EventsTable = ({ events, onEdit, onDelete, onDeleteSeries }: EventsTablePr
                   >
                     <Edit className="h-4 w-4" />
                   </Button>
+                  {onDuplicate && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      title="Dupliquer cet événement"
+                      onClick={() => onDuplicate(event)}
+                    >
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  )}
                   <Button
                     size="sm"
                     variant="destructive"

--- a/src/components/events/EventsTable.tsx
+++ b/src/components/events/EventsTable.tsx
@@ -3,15 +3,17 @@ type Event = Database["public"]["Tables"]["events"]["Row"];
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Card, CardContent } from "@/components/ui/card";
-import { Edit, Trash } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Edit, Trash, Repeat } from "lucide-react";
 
 interface EventsTableProps {
   events: Event[];
   onEdit: (event: Event) => void;
   onDelete: (id: string) => void;
+  onDeleteSeries?: (event: Event) => void;
 }
 
-const EventsTable = ({ events, onEdit, onDelete }: EventsTableProps) => (
+const EventsTable = ({ events, onEdit, onDelete, onDeleteSeries }: EventsTableProps) => (
   <Card>
     <CardContent className="p-6">
       <Table>
@@ -29,7 +31,15 @@ const EventsTable = ({ events, onEdit, onDelete }: EventsTableProps) => (
               <TableCell className="font-medium">{event.datetime}</TableCell>
               <TableCell>
                 <div className="max-w-xs">
-                  <p className="font-medium truncate">{event.name}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium truncate">{event.name}</p>
+                    {event.recurrence_id && (
+                      <Badge variant="secondary" className="gap-1 shrink-0">
+                        <Repeat className="h-3 w-3" />
+                        Récurrent
+                      </Badge>
+                    )}
+                  </div>
                 </div>
               </TableCell>
               <TableCell>
@@ -54,6 +64,17 @@ const EventsTable = ({ events, onEdit, onDelete }: EventsTableProps) => (
                   >
                     <Trash className="h-4 w-4" />
                   </Button>
+                  {event.recurrence_id && onDeleteSeries && (
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      title="Supprimer toute la série"
+                      onClick={() => onDeleteSeries(event)}
+                    >
+                      <Repeat className="h-4 w-4 mr-1" />
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
               </TableCell>
             </TableRow>

--- a/src/components/events/EventsTable.tsx
+++ b/src/components/events/EventsTable.tsx
@@ -5,6 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Edit, Trash, Repeat } from "lucide-react";
+import { describeRecurrenceFromEvent } from "@/lib/recurrence";
 
 interface EventsTableProps {
   events: Event[];
@@ -40,6 +41,11 @@ const EventsTable = ({ events, onEdit, onDelete, onDeleteSeries }: EventsTablePr
                       </Badge>
                     )}
                   </div>
+                  {event.recurrence_id && describeRecurrenceFromEvent(event) && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {describeRecurrenceFromEvent(event)}
+                    </p>
+                  )}
                 </div>
               </TableCell>
               <TableCell>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -30,6 +30,7 @@ export type Database = {
           name: string
           organization_id: string | null
           price: string | null
+          recurrence_id: string | null
           status: string
           theme_id: string | null
           ticketing_url: string | null
@@ -51,6 +52,7 @@ export type Database = {
           name: string
           organization_id?: string | null
           price?: string | null
+          recurrence_id?: string | null
           status?: string
           theme_id?: string | null
           ticketing_url?: string | null
@@ -72,6 +74,7 @@ export type Database = {
           name?: string
           organization_id?: string | null
           price?: string | null
+          recurrence_id?: string | null
           status?: string
           theme_id?: string | null
           ticketing_url?: string | null
@@ -79,6 +82,13 @@ export type Database = {
           url?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "events_recurrence_id_fkey"
+            columns: ["recurrence_id"]
+            isOneToOne: false
+            referencedRelation: "event_recurrences"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "events_organization_id_fkey"
             columns: ["organization_id"]
@@ -94,6 +104,39 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      event_recurrences: {
+        Row: {
+          created_at: string
+          end_date: string
+          frequency: string
+          id: string
+          interval: number
+          start_date: string
+          updated_at: string
+          weekdays: number[]
+        }
+        Insert: {
+          created_at?: string
+          end_date: string
+          frequency?: string
+          id?: string
+          interval?: number
+          start_date: string
+          updated_at?: string
+          weekdays?: number[]
+        }
+        Update: {
+          created_at?: string
+          end_date?: string
+          frequency?: string
+          id?: string
+          interval?: number
+          start_date?: string
+          updated_at?: string
+          weekdays?: number[]
+        }
+        Relationships: []
       }
       organization_invitations: {
         Row: {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -24,6 +24,7 @@ export type Database = {
           location_place: string | null
           name: string
           price: string | null
+          recurrence_id: string | null
           status: string
           theme_id: string | null
           updated_at: string
@@ -43,6 +44,7 @@ export type Database = {
           location_place?: string | null
           name: string
           price?: string | null
+          recurrence_id?: string | null
           status?: string
           theme_id?: string | null
           updated_at?: string
@@ -62,12 +64,20 @@ export type Database = {
           location_place?: string | null
           name?: string
           price?: string | null
+          recurrence_id?: string | null
           status?: string
           theme_id?: string | null
           updated_at?: string
           url?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "events_recurrence_id_fkey"
+            columns: ["recurrence_id"]
+            isOneToOne: false
+            referencedRelation: "event_recurrences"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "events_theme_id_fkey"
             columns: ["theme_id"]
@@ -76,6 +86,39 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      event_recurrences: {
+        Row: {
+          created_at: string
+          end_date: string
+          frequency: string
+          id: string
+          interval: number
+          start_date: string
+          updated_at: string
+          weekdays: number[]
+        }
+        Insert: {
+          created_at?: string
+          end_date: string
+          frequency?: string
+          id?: string
+          interval?: number
+          start_date: string
+          updated_at?: string
+          weekdays?: number[]
+        }
+        Update: {
+          created_at?: string
+          end_date?: string
+          frequency?: string
+          id?: string
+          interval?: number
+          start_date?: string
+          updated_at?: string
+          weekdays?: number[]
+        }
+        Relationships: []
       }
       themes: {
         Row: {

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -1,0 +1,126 @@
+import { daysOfWeek, monthNames } from "@/lib/utils";
+
+/**
+ * Règle de récurrence hebdomadaire.
+ * Les jours sont exprimés au format JS `getDay()` : 0 = dimanche … 6 = samedi.
+ */
+export type RecurrenceRule = {
+  interval: number; // toutes les X semaines (>= 1)
+  weekdays: number[]; // 0..6 (getDay)
+  startDate: string; // YYYY-MM-DD
+  endDate: string; // YYYY-MM-DD
+  startTime: string; // ex "16h30" (sert à construire le datetime français)
+};
+
+/**
+ * Champs partagés par toutes les occurrences d'une récurrence.
+ * Ce sont les champs d'un événement hors `datetime`/`date` (calculés par occurrence).
+ */
+export type RecurringSharedFields = {
+  name: string;
+  end_time?: string | null;
+  location_place?: string | null;
+  location_city?: string | null;
+  location_department?: string | null;
+  price?: string | null;
+  audience?: string | null;
+  emoji?: string | null;
+  url?: string | null;
+  ticketing_url?: string | null;
+  theme_id?: string | null;
+  cover_url?: string | null;
+  organization_id?: string | null;
+};
+
+/**
+ * Parse une date ISO `YYYY-MM-DD` en `Date` locale (midi pour éviter tout
+ * décalage de fuseau horaire). On n'utilise jamais `new Date(iso)` directement
+ * car il interpréterait la chaîne en UTC.
+ */
+function parseISODate(iso: string): Date {
+  const [year, month, day] = iso.split("-").map((part) => parseInt(part, 10));
+  return new Date(year, month - 1, day, 12, 0, 0, 0);
+}
+
+/** Formate une `Date` locale en `YYYY-MM-DD`. */
+function toISODate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Construit le datetime français attendu par l'app, ex :
+ * "mercredi 21 mai 2025 à 16h30". L'heure y est incluse au format `16h30`
+ * (cf. `formatTimeDisplay` dans utils.ts qui l'extrait par regex `\d{1,2}h\d{2}`).
+ */
+export function buildDatetimeString(dateISO: string, startTime: string): string {
+  const d = parseISODate(dateISO);
+  const dayName = daysOfWeek[d.getDay()];
+  const dayNumber = d.getDate();
+  const monthName = monthNames[d.getMonth()];
+  const year = d.getFullYear();
+  const time = startTime?.trim();
+  const base = `${dayName} ${dayNumber} ${monthName} ${year}`;
+  return time ? `${base} à ${time}` : base;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Calcule la liste triée des dates ISO des occurrences d'une récurrence
+ * hebdomadaire dans l'intervalle [startDate, endDate], pour les jours
+ * sélectionnés et en ne retenant qu'une semaine sur `interval`.
+ *
+ * Les "semaines" sont des tranches de 7 jours comptées **à partir de la date de
+ * début** (et non du lundi calendaire) : c'est le comportement le plus intuitif
+ * — « toutes les 2 semaines à partir du 1er juin » inclut bien la première
+ * occurrence dans la semaine du 1er juin.
+ */
+export function computeOccurrenceDates(rule: RecurrenceRule): string[] {
+  const { interval, weekdays, startDate, endDate } = rule;
+  if (!startDate || !endDate || !weekdays?.length) return [];
+
+  const start = parseISODate(startDate);
+  const end = parseISODate(endDate);
+  if (end < start) return [];
+
+  const step = Math.max(1, Math.floor(interval) || 1);
+  const weekdaySet = new Set(weekdays);
+
+  const dates: string[] = [];
+  const cursor = new Date(start);
+  // Borne de sécurité large pour éviter toute boucle infinie.
+  for (let safety = 0; safety < 4000 && cursor <= end; safety++) {
+    if (weekdaySet.has(cursor.getDay())) {
+      // Tranche de 7 jours depuis la date de début ; on ne garde qu'une
+      // tranche sur `step`.
+      const weekIndex = Math.floor((cursor.getTime() - start.getTime()) / MS_PER_DAY / 7);
+      if (weekIndex % step === 0) {
+        dates.push(toISODate(cursor));
+      }
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return dates;
+}
+
+/**
+ * Combine une règle de récurrence et les champs partagés en un tableau d'objets
+ * prêts à insérer dans la table `events` (chacun avec son `date` et son `datetime`).
+ * Les champs sont retournés tels quels ; la normalisation (ville/prix) et les
+ * métadonnées (status, recurrence_id, updated_at) sont ajoutées par l'appelant.
+ */
+export function buildRecurringEvents(
+  rule: RecurrenceRule,
+  shared: RecurringSharedFields,
+) {
+  const dates = computeOccurrenceDates(rule);
+  return dates.map((date) => ({
+    ...shared,
+    date,
+    datetime: buildDatetimeString(date, rule.startTime),
+  }));
+}

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -107,6 +107,62 @@ export function computeOccurrenceDates(rule: RecurrenceRule): string[] {
   return dates;
 }
 
+// Ordre d'affichage des jours (lundi → dimanche), exprimé en valeurs getDay().
+const WEEKDAY_DISPLAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
+
+/**
+ * Produit une description lisible d'une récurrence, ex :
+ * « Se répète toutes les 2 semaines, le mercredi et jeudi, de 18h à 22h ».
+ * Les horaires sont optionnels (extraits de l'événement, pas de la règle).
+ */
+export function describeRecurrence(
+  rule: { interval: number; weekdays: number[] },
+  opts?: { startTime?: string | null; endTime?: string | null },
+): string {
+  const parts: string[] = [];
+
+  // Rythme
+  const interval = Math.max(1, Math.floor(rule.interval) || 1);
+  parts.push(interval === 1 ? "toutes les semaines" : `toutes les ${interval} semaines`);
+
+  // Jours (triés dans l'ordre de la semaine)
+  const days = WEEKDAY_DISPLAY_ORDER
+    .filter((d) => rule.weekdays?.includes(d))
+    .map((d) => daysOfWeek[d]);
+  if (days.length === 1) {
+    parts.push(`le ${days[0]}`);
+  } else if (days.length > 1) {
+    const last = days[days.length - 1];
+    parts.push(`le ${days.slice(0, -1).join(", ")} et ${last}`);
+  }
+
+  // Horaires
+  const start = opts?.startTime?.trim();
+  const end = opts?.endTime?.trim();
+  if (start && end) {
+    parts.push(`de ${start} à ${end}`);
+  } else if (start) {
+    parts.push(`à ${start}`);
+  }
+
+  return `Se répète ${parts.join(", ")}`;
+}
+
+/**
+ * Décrit la récurrence d'un événement à partir de la règle jointe et de ses
+ * horaires (l'heure de début est extraite du `datetime`). Retourne null si
+ * l'événement n'est pas récurrent.
+ */
+export function describeRecurrenceFromEvent(event: {
+  datetime?: string | null;
+  end_time?: string | null;
+  recurrence?: { interval: number; weekdays: number[] } | null;
+}): string | null {
+  if (!event.recurrence) return null;
+  const startTime = event.datetime?.match(/\d{1,2}h\d{2}/)?.[0] ?? null;
+  return describeRecurrence(event.recurrence, { startTime, endTime: event.end_time });
+}
+
 /**
  * Combine une règle de récurrence et les champs partagés en un tableau d'objets
  * prêts à insérer dans la table `events` (chacun avec son `date` et son `datetime`).

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -53,7 +53,7 @@ function toISODate(date: Date): string {
 /**
  * Construit le datetime français attendu par l'app, ex :
  * "mercredi 21 mai 2025 à 16h30". L'heure y est incluse au format `16h30`
- * (cf. `formatTimeDisplay` dans utils.ts qui l'extrait par regex `\d{1,2}h\d{2}`).
+ * (cf. `formatTimeDisplay` dans utils.ts qui l'extrait par regex `\d{1,2}h\d{0,2}`).
  */
 export function buildDatetimeString(dateISO: string, startTime: string): string {
   const d = parseISODate(dateISO);
@@ -117,7 +117,7 @@ const WEEKDAY_DISPLAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
  */
 export function describeRecurrence(
   rule: { interval: number; weekdays: number[] },
-  opts?: { startTime?: string | null; endTime?: string | null },
+  opts?: { startTime?: string | null; endTime?: string | null; withPrefix?: boolean },
 ): string {
   const parts: string[] = [];
 
@@ -145,7 +145,12 @@ export function describeRecurrence(
     parts.push(`à ${start}`);
   }
 
-  return `Se répète ${parts.join(", ")}`;
+  const sentence = parts.join(", ");
+  if (opts?.withPrefix === false) {
+    // Sans préfixe : on capitalise la première lettre (« Toutes les… »).
+    return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+  }
+  return `Se répète ${sentence}`;
 }
 
 /**
@@ -153,14 +158,20 @@ export function describeRecurrence(
  * horaires (l'heure de début est extraite du `datetime`). Retourne null si
  * l'événement n'est pas récurrent.
  */
-export function describeRecurrenceFromEvent(event: {
-  datetime?: string | null;
-  end_time?: string | null;
-  recurrence?: { interval: number; weekdays: number[] } | null;
-}): string | null {
+export function describeRecurrenceFromEvent(
+  event: {
+    datetime?: string | null;
+    end_time?: string | null;
+    recurrence?: { interval: number; weekdays: number[] } | null;
+  },
+  opts?: { includeTime?: boolean; withPrefix?: boolean },
+): string | null {
   if (!event.recurrence) return null;
-  const startTime = event.datetime?.match(/\d{1,2}h\d{2}/)?.[0] ?? null;
-  return describeRecurrence(event.recurrence, { startTime, endTime: event.end_time });
+  // Côté front, l'horaire est déjà affiché ailleurs : on peut l'omettre.
+  const includeTime = opts?.includeTime !== false;
+  const startTime = includeTime ? (event.datetime?.match(/\d{1,2}h\d{0,2}/)?.[0] ?? null) : null;
+  const endTime = includeTime ? event.end_time : null;
+  return describeRecurrence(event.recurrence, { startTime, endTime, withPrefix: opts?.withPrefix });
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -85,7 +85,8 @@ export function getDateParts(event: Event) {
 
 export function formatTimeDisplay(event: Event) {
   if (!event.datetime) return "";
-  const timeMatch = event.datetime.match(/(\d{1,2}h\d{2})/);
+  // Les minutes sont optionnelles : on accepte « 14h » comme « 14h30 ».
+  const timeMatch = event.datetime.match(/(\d{1,2}h\d{0,2})/);
   if (timeMatch) {
     if (event.end_time) {
       return `${timeMatch[1]} — ${event.end_time}`;

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -17,14 +17,20 @@ import { useDebounce } from "@/hooks/use-debounce";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
-import { buildRecurringEvents, type RecurrenceRule, type RecurringSharedFields } from "@/lib/recurrence";
+import { buildRecurringEvents, describeRecurrenceFromEvent, type RecurrenceRule, type RecurringSharedFields } from "@/lib/recurrence";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Building2, Eye, Repeat } from "lucide-react";
+import { Building2, Eye, Repeat, Check, X, ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 type EventRow = Database["public"]["Tables"]["events"]["Row"];
 type ThemeRow = Database["public"]["Tables"]["themes"]["Row"];
@@ -98,7 +104,7 @@ const AdminDashboard = () => {
   const fetchPendingEvents = async () => {
     let query = supabase
       .from('events')
-      .select('*, theme:theme_id(*)')
+      .select('*, theme:theme_id(*), recurrence:recurrence_id(*)')
       .eq('status', 'pending');
 
     // Filtrer par organisation selon le type d'utilisateur
@@ -129,7 +135,7 @@ const AdminDashboard = () => {
     const to = from + pageSize - 1;
     let query = supabase
       .from('events')
-      .select('*, theme:theme_id(*)', { count: 'exact' })
+      .select('*, theme:theme_id(*), recurrence:recurrence_id(*)', { count: 'exact' })
       .eq('status', 'accepted');
 
     // Filtrer par organisation selon le type d'utilisateur
@@ -214,6 +220,30 @@ const AdminDashboard = () => {
       description: status === 'accepted'
         ? "Tous les événements de la série ont été acceptés."
         : "Tous les événements de la série ont été refusés.",
+    });
+    await fetchPendingEvents();
+    await fetchAcceptedEvents();
+  };
+
+  // Validation individuelle d'une proposition : ne change que l'occurrence ciblée.
+  const handleValidateSingle = async (event: EventRow, status: 'accepted' | 'rejected') => {
+    const { error } = await supabase
+      .from('events')
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq('id', event.id);
+    if (error) {
+      toast({
+        title: "Erreur lors de la validation",
+        description: error.message,
+        variant: "destructive",
+      });
+      return;
+    }
+    toast({
+      title: status === 'accepted' ? "Événement accepté" : "Événement refusé",
+      description: status === 'accepted'
+        ? "L'événement a été accepté."
+        : "L'événement a été refusé.",
     });
     await fetchPendingEvents();
     await fetchAcceptedEvents();
@@ -482,6 +512,11 @@ const AdminDashboard = () => {
                             </Badge>
                           )}
                         </div>
+                        {event.recurrence_id && describeRecurrenceFromEvent(event) && (
+                          <p className="text-xs text-muted-foreground mt-1">
+                            {describeRecurrenceFromEvent(event)}
+                          </p>
+                        )}
                       </div>
                     </TableCell>
                     <TableCell>
@@ -515,24 +550,72 @@ const AdminDashboard = () => {
                           <Eye className="w-4 h-4 mr-2" />
                           Voir
                         </Button>
-                        {event.recurrence_id && (
-                          <>
-                            <Button
-                              size="sm"
-                              className="bg-green-600 text-white hover:bg-green-700"
-                              onClick={() => handleValidateSeries(event, 'accepted')}
-                            >
-                              Accepter la série
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="destructive"
-                              onClick={() => handleValidateSeries(event, 'rejected')}
-                            >
-                              Refuser la série
-                            </Button>
-                          </>
-                        )}
+
+                        {/* Accepter : split button (action principale individuelle + menu série) */}
+                        <div className="flex">
+                          <Button
+                            size="sm"
+                            className={`bg-green-600 text-white hover:bg-green-700 ${event.recurrence_id ? 'rounded-r-none' : ''}`}
+                            title="Accepter cet événement"
+                            onClick={() => handleValidateSingle(event, 'accepted')}
+                          >
+                            <Check className="w-4 h-4 mr-1" />
+                            Accepter
+                          </Button>
+                          {event.recurrence_id && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  size="sm"
+                                  className="bg-green-600 text-white hover:bg-green-700 rounded-l-none border-l border-green-700 px-2"
+                                  title="Plus d'options"
+                                >
+                                  <ChevronDown className="w-4 h-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem onClick={() => handleValidateSeries(event, 'accepted')}>
+                                  <Repeat className="w-4 h-4 mr-2" />
+                                  Accepter la série
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </div>
+
+                        {/* Refuser : split button (action principale individuelle + menu série) */}
+                        <div className="flex">
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            className={event.recurrence_id ? 'rounded-r-none' : ''}
+                            title="Refuser cet événement"
+                            onClick={() => handleValidateSingle(event, 'rejected')}
+                          >
+                            <X className="w-4 h-4 mr-1" />
+                            Refuser
+                          </Button>
+                          {event.recurrence_id && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  size="sm"
+                                  variant="destructive"
+                                  className="rounded-l-none border-l border-red-800 px-2"
+                                  title="Plus d'options"
+                                >
+                                  <ChevronDown className="w-4 h-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem onClick={() => handleValidateSeries(event, 'rejected')}>
+                                  <Repeat className="w-4 h-4 mr-2" />
+                                  Refuser la série
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </div>
                       </div>
                     </TableCell>
                   </TableRow>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -17,13 +17,14 @@ import { useDebounce } from "@/hooks/use-debounce";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
+import { buildRecurringEvents, type RecurrenceRule, type RecurringSharedFields } from "@/lib/recurrence";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Building2, Eye } from "lucide-react";
+import { Building2, Eye, Repeat } from "lucide-react";
 
 type EventRow = Database["public"]["Tables"]["events"]["Row"];
 type ThemeRow = Database["public"]["Tables"]["themes"]["Row"];
@@ -41,6 +42,7 @@ const AdminDashboard = () => {
   const debouncedSearch = useDebounce(search, 400);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [eventToDelete, setEventToDelete] = useState<EventRow | null>(null);
+  const [deleteMode, setDeleteMode] = useState<'single' | 'series'>('single');
   const [showPastEvents, setShowPastEvents] = useState(false);
   
   const { toast } = useToast();
@@ -68,6 +70,7 @@ const AdminDashboard = () => {
     updated_at: '',
     organization_id: null,
     ticketing_url: null,
+    recurrence_id: null,
   };
 
   useEffect(() => {
@@ -179,11 +182,73 @@ const AdminDashboard = () => {
     const event = acceptedEvents.find(e => e.id === id);
     if (!event) return;
     setEventToDelete(event);
+    setDeleteMode('single');
     setShowDeleteConfirm(true);
+  };
+
+  const confirmDeleteSeries = (event: EventRow) => {
+    setEventToDelete(event);
+    setDeleteMode('series');
+    setShowDeleteConfirm(true);
+  };
+
+  // Validation groupée d'une proposition récurrente : passe toutes les occurrences
+  // en attente liées à la même récurrence en accepted/rejected.
+  const handleValidateSeries = async (event: EventRow, status: 'accepted' | 'rejected') => {
+    if (!event.recurrence_id) return;
+    const { error } = await supabase
+      .from('events')
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq('recurrence_id', event.recurrence_id)
+      .eq('status', 'pending');
+    if (error) {
+      toast({
+        title: "Erreur lors de la validation de la série",
+        description: error.message,
+        variant: "destructive",
+      });
+      return;
+    }
+    toast({
+      title: status === 'accepted' ? "Série acceptée" : "Série refusée",
+      description: status === 'accepted'
+        ? "Tous les événements de la série ont été acceptés."
+        : "Tous les événements de la série ont été refusés.",
+    });
+    await fetchPendingEvents();
+    await fetchAcceptedEvents();
   };
 
   const handleDeleteConfirmed = async () => {
     if (!eventToDelete) return;
+
+    // Suppression de la série complète : supprimer la récurrence supprime en
+    // cascade tous les événements liés.
+    if (deleteMode === 'series' && eventToDelete.recurrence_id) {
+      const { error: seriesError } = await supabase
+        .from('event_recurrences')
+        .delete()
+        .eq('id', eventToDelete.recurrence_id);
+      if (seriesError) {
+        toast({
+          title: "Erreur lors de la suppression de la série",
+          description: seriesError.message,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Série supprimée",
+          description: "Tous les événements de la série ont été supprimés.",
+        });
+        await fetchPendingEvents();
+        await fetchAcceptedEvents();
+      }
+      setShowDeleteConfirm(false);
+      setEventToDelete(null);
+      setDeleteMode('single');
+      return;
+    }
+
     const { error: deleteError } = await supabase.from('events').delete().eq('id', eventToDelete.id);
     if (deleteError) {
       toast({
@@ -200,6 +265,7 @@ const AdminDashboard = () => {
     }
     setShowDeleteConfirm(false);
     setEventToDelete(null);
+    setDeleteMode('single');
   };
 
   const handleSaveEvent = async (eventData: Omit<EventRow, 'id'> & { id?: string }) => {
@@ -283,6 +349,75 @@ const AdminDashboard = () => {
     return success;
   };
 
+  // Création groupée d'un événement récurrent : 1 ligne event_recurrences + N events liés.
+  const handleSaveRecurringEvent = async (
+    rule: RecurrenceRule,
+    shared: RecurringSharedFields,
+  ): Promise<boolean> => {
+    const occurrences = buildRecurringEvents(rule, shared);
+    if (occurrences.length === 0) {
+      toast({
+        title: "Aucune occurrence",
+        description: "La récurrence ne génère aucun événement sur la période choisie.",
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    // 1. Créer la règle de récurrence.
+    const { data: recurrenceData, error: recurrenceError } = await supabase
+      .from('event_recurrences')
+      .insert({
+        frequency: 'weekly',
+        interval: rule.interval,
+        weekdays: rule.weekdays,
+        start_date: rule.startDate,
+        end_date: rule.endDate,
+      })
+      .select()
+      .single();
+
+    if (recurrenceError || !recurrenceData) {
+      toast({
+        title: "Erreur lors de la création de la récurrence",
+        description: recurrenceError?.message ?? "Erreur inconnue",
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    // 2. Insérer les occurrences liées.
+    const now = new Date().toISOString();
+    const rows = occurrences.map((occ) => ({
+      ...occ,
+      recurrence_id: recurrenceData.id,
+      status: 'accepted',
+      updated_at: now,
+    }));
+
+    const { error: insertError } = await supabase.from('events').insert(rows);
+
+    if (insertError) {
+      // Rollback : supprimer la récurrence (cascade sur les events déjà insérés).
+      await supabase.from('event_recurrences').delete().eq('id', recurrenceData.id);
+      toast({
+        title: "Erreur lors de la création des événements",
+        description: insertError.message,
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    toast({
+      title: "Événements créés",
+      description: `${rows.length} événements récurrents ont été créés.`,
+    });
+    await fetchPendingEvents();
+    await fetchAcceptedEvents();
+    setShowForm(false);
+    return true;
+  };
+
   // Affichage d'un message si l'utilisateur n'a pas d'organisation et n'est pas super admin
   if (!isSuperAdmin && organizations.length === 0) {
     return (
@@ -338,7 +473,15 @@ const AdminDashboard = () => {
                     <TableCell className="font-medium">{event.datetime}</TableCell>
                     <TableCell>
                       <div className="max-w-xs">
-                        <p className="font-medium truncate">{event.name}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium truncate">{event.name}</p>
+                          {event.recurrence_id && (
+                            <Badge variant="secondary" className="gap-1 shrink-0">
+                              <Repeat className="h-3 w-3" />
+                              Récurrent
+                            </Badge>
+                          )}
+                        </div>
                       </div>
                     </TableCell>
                     <TableCell>
@@ -363,14 +506,34 @@ const AdminDashboard = () => {
                       </div>
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button 
-                        variant="outline" 
-                        size="sm"
-                        onClick={() => { setCurrentEvent(event); setShowForm(true); }}
-                      >
-                        <Eye className="w-4 h-4 mr-2" />
-                        Voir
-                      </Button>
+                      <div className="flex justify-end gap-2 flex-wrap">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => { setCurrentEvent(event); setShowForm(true); }}
+                        >
+                          <Eye className="w-4 h-4 mr-2" />
+                          Voir
+                        </Button>
+                        {event.recurrence_id && (
+                          <>
+                            <Button
+                              size="sm"
+                              className="bg-green-600 text-white hover:bg-green-700"
+                              onClick={() => handleValidateSeries(event, 'accepted')}
+                            >
+                              Accepter la série
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => handleValidateSeries(event, 'rejected')}
+                            >
+                              Refuser la série
+                            </Button>
+                          </>
+                        )}
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -391,7 +554,7 @@ const AdminDashboard = () => {
         onTogglePastEvents={setShowPastEvents}
       />
       {/* Tableau principal des événements */}
-      <EventsTable events={acceptedEvents} onEdit={handleEditEvent} onDelete={confirmDeleteEvent} />
+      <EventsTable events={acceptedEvents} onEdit={handleEditEvent} onDelete={confirmDeleteEvent} onDeleteSeries={confirmDeleteSeries} />
       <EventsPagination page={page} total={total} pageSize={pageSize} onPageChange={setPage} />
       <Dialog open={showForm} onOpenChange={setShowForm}>
         <DialogContent className={`w-3/4 max-w-4xl mx-auto ${theme === 'light' ? 'bg-[#f8f8f6] text-ephemeride border-none' : 'bg-ephemeride-light text-ephemeride-foreground border-none'}`} >
@@ -447,15 +610,20 @@ const AdminDashboard = () => {
             onCancel={() => setShowForm(false)}
             showValidationActions={currentEvent?.status === 'pending'}
             themes={themes}
+            onSaveRecurring={handleSaveRecurringEvent}
           />
         </DialogContent>
       </Dialog>
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Confirmer la suppression</DialogTitle>
+            <DialogTitle>{deleteMode === 'series' ? "Supprimer la série" : "Confirmer la suppression"}</DialogTitle>
           </DialogHeader>
-          <p>Voulez-vous vraiment supprimer l'événement <b>{eventToDelete?.name}</b> ?</p>
+          {deleteMode === 'series' ? (
+            <p>Voulez-vous vraiment supprimer <b>toute la série récurrente</b> de l'événement <b>{eventToDelete?.name}</b> ? Tous les événements liés seront supprimés.</p>
+          ) : (
+            <p>Voulez-vous vraiment supprimer l'événement <b>{eventToDelete?.name}</b> ?</p>
+          )}
           <div className="flex justify-end gap-2 mt-4">
             <button
               className="btn btn-secondary"

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -44,6 +44,7 @@ const AdminDashboard = () => {
   const pageSize = 25;
   const [showForm, setShowForm] = useState(false);
   const [currentEvent, setCurrentEvent] = useState<EventRow | undefined>(undefined);
+  const [duplicateMode, setDuplicateMode] = useState(false);
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, 400);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -176,11 +177,21 @@ const AdminDashboard = () => {
 
   const handleAddEvent = () => {
     setCurrentEvent(undefined);
+    setDuplicateMode(false);
     setShowForm(true);
   };
 
   const handleEditEvent = (event: EventRow) => {
     setCurrentEvent(event);
+    setDuplicateMode(false);
+    setShowForm(true);
+  };
+
+  // Duplication : ouvre le formulaire de création pré-rempli avec l'événement
+  // source (et sa récurrence si applicable).
+  const handleDuplicateEvent = (event: EventRow) => {
+    setCurrentEvent(event);
+    setDuplicateMode(true);
     setShowForm(true);
   };
 
@@ -545,7 +556,7 @@ const AdminDashboard = () => {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => { setCurrentEvent(event); setShowForm(true); }}
+                          onClick={() => { setCurrentEvent(event); setDuplicateMode(false); setShowForm(true); }}
                         >
                           <Eye className="w-4 h-4 mr-2" />
                           Voir
@@ -637,12 +648,12 @@ const AdminDashboard = () => {
         onTogglePastEvents={setShowPastEvents}
       />
       {/* Tableau principal des événements */}
-      <EventsTable events={acceptedEvents} onEdit={handleEditEvent} onDelete={confirmDeleteEvent} onDeleteSeries={confirmDeleteSeries} />
+      <EventsTable events={acceptedEvents} onEdit={handleEditEvent} onDelete={confirmDeleteEvent} onDeleteSeries={confirmDeleteSeries} onDuplicate={handleDuplicateEvent} />
       <EventsPagination page={page} total={total} pageSize={pageSize} onPageChange={setPage} />
       <Dialog open={showForm} onOpenChange={setShowForm}>
         <DialogContent className={`w-3/4 max-w-4xl mx-auto ${theme === 'light' ? 'bg-[#f8f8f6] text-ephemeride border-none' : 'bg-ephemeride-light text-ephemeride-foreground border-none'}`} >
           <DialogHeader>
-            <DialogTitle>{currentEvent ? (currentEvent.status === 'pending' ? "Valider une proposition" : "Modifier l'événement") : "Ajouter un événement"}</DialogTitle>
+            <DialogTitle>{duplicateMode ? "Dupliquer un événement" : currentEvent ? (currentEvent.status === 'pending' ? "Valider une proposition" : "Modifier l'événement") : "Ajouter un événement"}</DialogTitle>
           </DialogHeader>
           <EventForm
             event={currentEvent}
@@ -677,8 +688,9 @@ const AdminDashboard = () => {
                   toast({ title: "Événement refusé", description: "L'événement a été refusé." });
                   return true;
                 } else {
-                  // Edition classique ou ajout
-                  const success = await handleSaveEvent({ ...eventData, id: currentEvent?.id } as Omit<EventRow, 'id'> & { id?: string });
+                  // Edition classique, ajout, ou duplication (création : pas d'id source)
+                  const idToSave = duplicateMode ? undefined : currentEvent?.id;
+                  const success = await handleSaveEvent({ ...eventData, id: idToSave } as Omit<EventRow, 'id'> & { id?: string });
                   return success;
                 }
               } catch (error) {
@@ -691,9 +703,10 @@ const AdminDashboard = () => {
               }
             }}
             onCancel={() => setShowForm(false)}
-            showValidationActions={currentEvent?.status === 'pending'}
+            showValidationActions={currentEvent?.status === 'pending' && !duplicateMode}
             themes={themes}
             onSaveRecurring={handleSaveRecurringEvent}
+            duplicate={duplicateMode}
           />
         </DialogContent>
       </Dialog>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -78,7 +78,7 @@ const Index = () => {
       // Requête pour les événements futurs uniquement
       let futureQuery = supabase
         .from('events')
-        .select('*, theme:theme_id(*)')
+        .select('*, theme:theme_id(*), recurrence:recurrence_id(*)')
         .eq('status', 'accepted')
         .gte('date', today); // Filtrer uniquement les événements futurs ou d'aujourd'hui
 

--- a/supabase/migrations/20260617120000_event_recurrences.sql
+++ b/supabase/migrations/20260617120000_event_recurrences.sql
@@ -1,0 +1,50 @@
+-- Récurrence d'événements : une règle de récurrence (hebdomadaire) génère plusieurs
+-- événements individuels, tous liés via events.recurrence_id.
+
+create table if not exists public.event_recurrences (
+  id uuid primary key default gen_random_uuid(),
+  frequency text not null default 'weekly',                    -- extensible (futur : monthly)
+  interval integer not null default 1 check (interval >= 1),   -- toutes les X semaines
+  weekdays integer[] not null default '{}',                    -- 0=dimanche .. 6=samedi (= JS getDay)
+  start_date date not null,
+  end_date date not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Lien des événements vers leur récurrence. La suppression de la récurrence
+-- supprime en cascade tous les événements générés (gestion groupée de la série).
+alter table public.events
+  add column if not exists recurrence_id uuid references public.event_recurrences(id) on delete cascade;
+
+create index if not exists events_recurrence_id_idx on public.events(recurrence_id);
+
+alter table public.event_recurrences enable row level security;
+
+-- Lecture publique : le front lit les événements liés (et leur récurrence).
+drop policy if exists "event_recurrences_public_read" on public.event_recurrences;
+create policy "event_recurrences_public_read"
+  on public.event_recurrences
+  for select
+  using (true);
+
+-- Insert public : nécessaire pour les propositions publiques récurrentes
+-- (aligné sur la table events qui accepte les propositions anonymes).
+drop policy if exists "event_recurrences_public_insert" on public.event_recurrences;
+create policy "event_recurrences_public_insert"
+  on public.event_recurrences
+  for insert
+  with check (true);
+
+-- Mise à jour / suppression réservées aux utilisateurs authentifiés (admin).
+drop policy if exists "event_recurrences_auth_update" on public.event_recurrences;
+create policy "event_recurrences_auth_update"
+  on public.event_recurrences
+  for update
+  using (auth.role() = 'authenticated');
+
+drop policy if exists "event_recurrences_auth_delete" on public.event_recurrences;
+create policy "event_recurrences_auth_delete"
+  on public.event_recurrences
+  for delete
+  using (auth.role() = 'authenticated');


### PR DESCRIPTION
Implémente l'issue #1 : créer des **événements récurrents** (hebdomadaires), les gérer en admin et les afficher côté front.

## Fonctionnalités

**Création**
- Sélecteur de type **Ponctuel** (défaut) / **Récurrent**, en admin **et** dans la dialog de proposition publique.
- Rythme « toutes les X semaines », jours (L M M J V S D via toggles), plage de dates début → fin, heures début/fin.
- Génère un événement individuel par occurrence, tous liés en base.

**Base de données**
- Nouvelle table `event_recurrences` (règle : fréquence, intervalle, jours, dates).
- Colonne `events.recurrence_id` (FK `ON DELETE CASCADE`) + RLS.
- Migration appliquée sur le projet distant.

**Gestion admin**
- Badge « Récurrent » + résumé lisible (« Se répète toutes les 2 semaines, le mercredi et jeudi, de 14h à 16h »).
- Suppression de toute la série (cascade).
- Validation des propositions en **split buttons** : action principale individuelle + menu « la série » (acceptation/refus groupés).
- Action **Dupliquer** : ouvre un formulaire de création pré-rempli (récurrence pré-remplie si la source est récurrente).

**Front**
- Label de récurrence sur les cartes, au niveau du prix (« Toutes les 2 semaines, le mardi et mercredi »).
- Correctifs d'affichage de l'heure (« 14h » sans minutes), cohérence « Aujourd'hui », largeur fixe du bloc date.

## Notes
- `EventCard.tsx` embarque aussi la fonctionnalité d'édition inline admin (travail en cours, non séparable du label de récurrence dans le même fichier).
- L'historique des migrations Supabase a été réaligné (les anciennes migrations appliquées via le dashboard étaient absentes du repo).

## Vérification
- `tsc`, `eslint`, `vite build` : OK.
- Migration vérifiée sur le remote (table + colonne accessibles via l'API).