### PR TITLE
Dissocier date et heure des événements via start_at/end_at (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn.lock
 
 # Supabase CLI
 supabase/.temp/
+
+# Dumps de base de données (contiennent des données de prod) + scripts ad hoc
+backups/

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -10,7 +10,7 @@ import { useState, useEffect } from "react";
 import EventForm from "@/components/EventForm";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
-import { getDayOfWeek, getDateBlockColor, monthNamesShort, getDateParts, formatTimeDisplay, isToday, formatCityName, formatPrice } from "@/lib/utils";
+import { daysOfWeek, getDateBlockColor, getDateParts, getEventStart, formatTimeDisplay, isToday, formatCityName, formatPrice } from "@/lib/utils";
 import { describeRecurrenceFromEvent } from "@/lib/recurrence";
 
 interface EventCardProps {
@@ -65,6 +65,8 @@ const EventCard = ({ event: eventProp, isPast = false }: EventCardProps) => {
   };
 
   const { day, month, year } = getDateParts(event);
+  const eventStart = getEventStart(event);
+  const dayName = eventStart ? daysOfWeek[eventStart.getDay()] : "lundi";
   const recurrenceLabel = describeRecurrenceFromEvent(event, { includeTime: false, withPrefix: false });
 
   // Format location
@@ -73,7 +75,7 @@ const EventCard = ({ event: eventProp, isPast = false }: EventCardProps) => {
   const cardContent = (
     <div className="flex h-full">
       {/* Date block à gauche */}
-      <div className={`${getDateBlockColor(event.date ? getDayOfWeek(event.date) : "lundi")} text-white flex flex-col items-center justify-center px-4 py-6 w-[150px] flex-shrink-0 ${isPast ? 'opacity-60' : ''}`}>
+      <div className={`${getDateBlockColor(dayName)} text-white flex flex-col items-center justify-center px-4 py-6 w-[150px] flex-shrink-0 ${isPast ? 'opacity-60' : ''}`}>
         {isToday(event) ? (
           <>
             <div className="text-lg font-bold leading-none mb-1">Aujourd'hui</div>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -12,7 +12,7 @@ import { useDropzone } from "react-dropzone";
 import { X } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
-import { formatCityName, formatPrice } from "@/lib/utils";
+import { formatCityName, formatPrice, getEventStart, getEventEnd } from "@/lib/utils";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import RecurrenceFields from "@/components/RecurrenceFields";
 import type { RecurrenceRule, RecurringSharedFields } from "@/lib/recurrence";
@@ -22,9 +22,9 @@ type Theme = Database["public"]["Tables"]["themes"]["Row"];
 
 type EventFormValues = {
   id?: string;
-  datetime: string;
-  date: string;
-  end_time?: string | null;
+  date: string;        // YYYY-MM-DD
+  start_time: string;  // HH:MM
+  end_time?: string | null; // HH:MM
   name: string;
   location_place?: string;
   location_city: string;
@@ -67,12 +67,13 @@ const defaultRecurrence: RecurrenceRule = {
   startDate: '',
   endDate: '',
   startTime: '',
+  endTime: '',
 };
 
 const defaultValues: EventFormValues = {
   id: '',
-  datetime: '',
   date: '',
+  start_time: '',
   end_time: '',
   name: '',
   location_place: '',
@@ -134,7 +135,21 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
       const newValues = {
         ...defaultValues,
         ...sanitizedEvent,
-      };
+      } as EventFormValues & Record<string, unknown>;
+
+      // Dériver date / heures depuis start_at / end_at (avec fallback legacy
+      // géré par les helpers). On retire les champs qui ne sont pas des entrées
+      // de formulaire pour ne pas les renvoyer tels quels à la sauvegarde.
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const toTime = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      const start = getEventStart(event);
+      const end = getEventEnd(event);
+      newValues.date = start ? `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())}` : '';
+      newValues.start_time = start ? toTime(start) : '';
+      newValues.end_time = end ? toTime(end) : '';
+      delete newValues.datetime;
+      delete newValues.start_at;
+      delete newValues.end_at;
 
       // En duplication : on crée un nouvel événement, donc pas d'id ni de lien
       // de récurrence hérités.
@@ -143,19 +158,19 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
         newValues.recurrence_id = null;
       }
 
-      setFormData(newValues);
-      formDataRef.current = newValues;
+      setFormData(newValues as EventFormValues);
+      formDataRef.current = newValues as EventFormValues;
 
       // Duplication d'un événement récurrent : pré-remplir la récurrence.
       if (duplicate && event.recurrence) {
-        const startTime = event.datetime?.match(/\d{1,2}h\d{2}/)?.[0] ?? '';
         setEventType('recurring');
         setRecurrence({
           interval: event.recurrence.interval,
           weekdays: event.recurrence.weekdays,
           startDate: event.recurrence.start_date,
           endDate: event.recurrence.end_date,
-          startTime,
+          startTime: start ? toTime(start) : '',
+          endTime: end ? toTime(end) : '',
         });
       } else {
         setEventType('single');
@@ -223,6 +238,16 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
     return selectedOrgId ?? null;
   };
 
+  // Transforme les champs de formulaire en payload de colonnes : combine
+  // date + heures en start_at / end_at et écarte les champs propres au formulaire
+  // (date, start_time, end_time) qui ne sont pas des colonnes de la table.
+  const toEventPayload = (values: EventFormValues): Partial<Event> => {
+    const { date, start_time, end_time, ...rest } = values;
+    const start_at = date && start_time ? `${date}T${start_time}:00` : null;
+    const end_at = date && end_time ? `${date}T${end_time}:00` : null;
+    return { ...rest, start_at, end_at };
+  };
+
   const onSubmit = async (data: Partial<Event>) => {
     // Nettoyer les données : convertir les chaînes vides en null pour la base de données
     const cleanData = Object.fromEntries(
@@ -285,7 +310,6 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
 
     const shared: RecurringSharedFields = {
       name: currentFormData.name,
-      end_time: currentFormData.end_time || null,
       location_place: currentFormData.location_place || null,
       location_city: formatCityName(currentFormData.location_city),
       location_department: currentFormData.location_department || null,
@@ -331,13 +355,13 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
       errors.push('Nom de l\'événement');
       fieldErrors.name = 'Le nom de l\'événement est obligatoire';
     }
-    if (!currentFormData.datetime?.trim()) {
-      errors.push('Date et heure');
-      fieldErrors.datetime = 'La date et heure sont obligatoires';
-    }
     if (!currentFormData.date?.trim()) {
-      errors.push('Date réelle');
-      fieldErrors.date = 'La date réelle est obligatoire';
+      errors.push('Date');
+      fieldErrors.date = 'La date est obligatoire';
+    }
+    if (!currentFormData.start_time?.trim()) {
+      errors.push('Heure de début');
+      fieldErrors.start_time = "L'heure de début est obligatoire";
     }
     if (!currentFormData.location_city?.trim()) {
       errors.push('Ville');
@@ -370,7 +394,7 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
       price: currentFormData.price ? formatPrice(currentFormData.price) : currentFormData.price,
     };
 
-    await onSubmit(normalizedFormData);
+    await onSubmit(toEventPayload(normalizedFormData));
   };
 
   return (
@@ -485,30 +509,13 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
                 <RecurrenceFields
                   value={recurrence}
                   onChange={setRecurrence}
-                  endTime={formData.end_time || ''}
-                  onEndTimeChange={(value) => setFormData(prev => ({ ...prev, end_time: value }))}
                   theme={theme}
                   errors={validationErrors}
                 />
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="datetime">Date et heure *</Label>
-                    <Input
-                      id="datetime"
-                      value={formData.datetime || ''}
-                      onChange={(e) => setFormData(prev => ({ ...prev, datetime: e.target.value }))}
-                      placeholder="ex: mercredi 21 mai 2025 à 16h30"
-                      className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.datetime ? 'border-red-500 focus:border-red-500' : ''}`}
-                    />
-                    {validationErrors.datetime ? (
-                      <p className="text-red-500 text-sm">{validationErrors.datetime}</p>
-                    ) : (
-                      <p className="text-xs text-white/60">Format : jour date mois année à/de heure</p>
-                    )}
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="date">Date réelle *</Label>
+                    <Label htmlFor="date">Date *</Label>
                     <Input
                       id="date"
                       type="date"
@@ -516,19 +523,30 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
                       onChange={(e) => setFormData(prev => ({ ...prev, date: e.target.value }))}
                       className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.date ? 'border-red-500 focus:border-red-500' : ''}`}
                     />
-                    {validationErrors.date ? (
+                    {validationErrors.date && (
                       <p className="text-red-500 text-sm">{validationErrors.date}</p>
-                    ) : (
-                      <p className="text-xs text-white/60">Permet un tri fiable par date</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="start_time">Heure de début *</Label>
+                    <Input
+                      id="start_time"
+                      type="time"
+                      value={formData.start_time || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, start_time: e.target.value }))}
+                      className={`${theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'} ${validationErrors.start_time ? 'border-red-500 focus:border-red-500' : ''}`}
+                    />
+                    {validationErrors.start_time && (
+                      <p className="text-red-500 text-sm">{validationErrors.start_time}</p>
                     )}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="end_time">Heure de fin (optionnel)</Label>
                     <Input
                       id="end_time"
+                      type="time"
                       value={formData.end_time || ''}
                       onChange={(e) => setFormData(prev => ({ ...prev, end_time: e.target.value }))}
-                      placeholder="ex: 19h00"
                       className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B]' : 'border-white/20 bg-white/10 text-white'}
                     />
                   </div>
@@ -688,7 +706,7 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
                 type="button"
                 className="bg-green-600 text-white hover:bg-green-700"
                 disabled={false}
-                onClick={() => onSave({ ...formData, status: 'accepted' })}
+                onClick={() => onSave({ ...toEventPayload(formData), status: 'accepted' })}
               >
                 Accepter
               </Button>
@@ -696,7 +714,7 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
                 type="button"
                 className="bg-red-600 text-white hover:bg-red-700"
                 disabled={false}
-                onClick={() => onSave({ ...formData, status: 'rejected' })}
+                onClick={() => onSave({ ...toEventPayload(formData), status: 'rejected' })}
               >
                 Refuser
               </Button>

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Share, Mail, MessageSquare, Send, ChevronDown, ChevronUp } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { getDayOfWeek, daysOfWeek, monthNames, monthNamesShort, getDateBlockColor } from "@/lib/utils";
+import { daysOfWeek, monthNames, monthNamesShort, getDateBlockColor, getEventStart } from "@/lib/utils";
 import EventFilters from "@/components/events/EventFilters";
 import type { FilterValues } from "@/lib/eventFilters";
 
@@ -58,16 +58,18 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
   useEffect(() => {
     const now = new Date();
     const todayStr = now.toISOString().slice(0, 10); // YYYY-MM-DD
+    const pad = (n: number) => String(n).padStart(2, "0");
     const upcoming: Event[] = [];
 
     events.forEach(event => {
-      if (event.date) {
-        if (event.date >= todayStr) {
-          upcoming.push(event);
-        }
+      const start = getEventStart(event);
+      if (!start) return;
+      const startStr = `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())}`;
+      if (startStr >= todayStr) {
+        upcoming.push(event);
       }
     });
-    
+
     setUpcomingEvents(upcoming);
   }, [events]);
 
@@ -83,22 +85,18 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
     const grouped: Record<string, Record<string, Event[]>> = {};
     
     eventList.forEach(event => {
-      if (!event.date) return;
-      let dateKey = event.datetime.split(" à ")[0].split(" de ")[0];
-      let monthKey = "";
-      // dateKey = YYYY-MM-DD
-      const [year, month, day] = event.date.split("-");
-      dateKey = `${day} ${monthNames[parseInt(month, 10)-1].toLowerCase()} ${year}`;
-      monthKey = `${monthNames[parseInt(month, 10)-1]} ${year}`;
-      if (monthKey) {
-        if (!grouped[monthKey]) {
-          grouped[monthKey] = {};
-        }
-        if (!grouped[monthKey][dateKey]) {
-          grouped[monthKey][dateKey] = [];
-        }
-        grouped[monthKey][dateKey].push(event);
+      const start = getEventStart(event);
+      if (!start) return;
+      const monthName = monthNames[start.getMonth()];
+      const dateKey = `${start.getDate()} ${monthName.toLowerCase()} ${start.getFullYear()}`;
+      const monthKey = `${monthName} ${start.getFullYear()}`;
+      if (!grouped[monthKey]) {
+        grouped[monthKey] = {};
       }
+      if (!grouped[monthKey][dateKey]) {
+        grouped[monthKey][dateKey] = [];
+      }
+      grouped[monthKey][dateKey].push(event);
     });
     
     return grouped;
@@ -221,10 +219,8 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
             
             {Object.entries(dayEvents).map(([date, events]) => {
               const firstEvent = events[0];
-              let dayOfWeek = "";
-              if (firstEvent && firstEvent.date) {
-                dayOfWeek = getDayOfWeek(firstEvent.date);
-              }
+              const firstStart = firstEvent ? getEventStart(firstEvent) : null;
+              const dayOfWeek = firstStart ? daysOfWeek[firstStart.getDay()] : "";
               const stickyBg = theme === "light" ? "bg-[#faf3ec]" : "bg-[#1B263B]";
               return (
                 <div key={date} className="mb-6">
@@ -280,12 +276,10 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
                 </div>
                 
                 {Object.entries(dayEvents).map(([date, events]) => {
-                  // On récupère la date ISO de l'événement pour le jour de la semaine
+                  // Jour de la semaine dérivé de la date+heure de début.
                   const firstEvent = events[0];
-                  let dayOfWeek = "";
-                  if (firstEvent && firstEvent.date) {
-                    dayOfWeek = getDayOfWeek(firstEvent.date);
-                  }
+                  const firstStart = firstEvent ? getEventStart(firstEvent) : null;
+                  const dayOfWeek = firstStart ? daysOfWeek[firstStart.getDay()] : "";
                   return (
                     <div key={date} className="mb-6">
                       <h3 className={`text-xl font-medium border-b border-white/20 pb-2 mb-4 ${textColorClass}`}>

--- a/src/components/EventProposalForm.tsx
+++ b/src/components/EventProposalForm.tsx
@@ -26,7 +26,8 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
   const [recurrence, setRecurrence] = useState<RecurrenceRule>(defaultRecurrence);
   const [formData, setFormData] = useState({
     name: "",
-    datetime: "",
+    date: "",
+    startTime: "",
     endTime: "",
     location: {
       place: "",
@@ -66,7 +67,6 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
   // Champs partagés par toutes les occurrences (et utilisés en mode ponctuel).
   const buildSharedFields = () => ({
     name: formData.name,
-    end_time: formData.endTime || null,
     location_place: formData.location.place || null,
     location_city: formData.location.city ? formatCityName(formData.location.city) : null,
     location_department: formData.location.department || null,
@@ -158,10 +158,10 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
     }
 
     // Mode ponctuel
-    if (!formData.name || !formData.datetime) {
+    if (!formData.name || !formData.date || !formData.startTime) {
       toast({
         title: "Informations manquantes",
-        description: "Veuillez remplir tous les champs obligatoires",
+        description: "Veuillez remplir le nom, la date et l'heure de début",
         variant: "destructive",
       });
       return;
@@ -169,7 +169,8 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
 
     const { error } = await supabase.from("events").insert({
       ...buildSharedFields(),
-      datetime: formData.datetime,
+      start_at: `${formData.date}T${formData.startTime}:00`,
+      end_at: formData.endTime ? `${formData.date}T${formData.endTime}:00` : null,
       status: "pending",
       createdby,
     });
@@ -232,21 +233,31 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
                 <RecurrenceFields
                   value={recurrence}
                   onChange={setRecurrence}
-                  endTime={formData.endTime}
-                  onEndTimeChange={(value) => setFormData(prev => ({ ...prev, endTime: value }))}
                   theme={theme}
                 />
               </div>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
-                  <Label htmlFor="datetime" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Date et heure *</Label>
+                  <Label htmlFor="date" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Date *</Label>
                   <Input
-                    id="datetime"
-                    name="datetime"
+                    id="date"
+                    name="date"
+                    type="date"
                     required
-                    placeholder="ex: mercredi 21 mai 2025 à 16h30"
-                    value={formData.datetime}
+                    value={formData.date}
+                    onChange={handleChange}
+                    className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="startTime" className={theme === 'light' ? 'text-[#1B263B]' : 'text-white'}>Heure de début *</Label>
+                  <Input
+                    id="startTime"
+                    name="startTime"
+                    type="time"
+                    required
+                    value={formData.startTime}
                     onChange={handleChange}
                     className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}
                   />
@@ -256,7 +267,7 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
                   <Input
                     id="endTime"
                     name="endTime"
-                    placeholder="ex: 19h00"
+                    type="time"
                     value={formData.endTime}
                     onChange={handleChange}
                     className={theme === 'light' ? 'border-[#f3e0c7] bg-white text-[#1B263B] mt-1' : 'border-white/20 bg-white/10 text-white mt-1'}

--- a/src/components/RecurrenceFields.tsx
+++ b/src/components/RecurrenceFields.tsx
@@ -17,8 +17,6 @@ const WEEKDAYS: { label: string; value: number }[] = [
 interface RecurrenceFieldsProps {
   value: RecurrenceRule;
   onChange: (value: RecurrenceRule) => void;
-  endTime: string;
-  onEndTimeChange: (value: string) => void;
   theme?: "light" | "dark";
   errors?: { [key: string]: string };
 }
@@ -26,8 +24,6 @@ interface RecurrenceFieldsProps {
 const RecurrenceFields = ({
   value,
   onChange,
-  endTime,
-  onEndTimeChange,
   theme = "dark",
   errors = {},
 }: RecurrenceFieldsProps) => {
@@ -78,9 +74,9 @@ const RecurrenceFields = ({
           <Label htmlFor="recurrence_start_time">Heure de début *</Label>
           <Input
             id="recurrence_start_time"
+            type="time"
             value={value.startTime || ""}
             onChange={(e) => update({ startTime: e.target.value })}
-            placeholder="ex: 14h00"
             className={`${inputClass} ${errors.startTime ? "border-red-500 focus:border-red-500" : ""}`}
           />
           {errors.startTime && <p className="text-red-500 text-sm">{errors.startTime}</p>}
@@ -89,9 +85,9 @@ const RecurrenceFields = ({
           <Label htmlFor="recurrence_end_time">Heure de fin (optionnel)</Label>
           <Input
             id="recurrence_end_time"
-            value={endTime || ""}
-            onChange={(e) => onEndTimeChange(e.target.value)}
-            placeholder="ex: 19h00"
+            type="time"
+            value={value.endTime || ""}
+            onChange={(e) => update({ endTime: e.target.value })}
             className={inputClass}
           />
         </div>

--- a/src/components/events/EventsTable.tsx
+++ b/src/components/events/EventsTable.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Edit, Trash, Repeat, Copy } from "lucide-react";
 import { describeRecurrenceFromEvent } from "@/lib/recurrence";
+import { formatEventDateTimeLabel } from "@/lib/utils";
 
 interface EventsTableProps {
   events: Event[];
@@ -30,7 +31,7 @@ const EventsTable = ({ events, onEdit, onDelete, onDeleteSeries, onDuplicate }: 
         <TableBody>
           {events.map((event) => (
             <TableRow key={event.id}>
-              <TableCell className="font-medium">{event.datetime}</TableCell>
+              <TableCell className="font-medium">{formatEventDateTimeLabel(event)}</TableCell>
               <TableCell>
                 <div className="max-w-xs">
                   <div className="flex items-center gap-2">

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -20,10 +20,12 @@ export type Database = {
           cover_url: string | null
           createdby: Json | null
           date: string | null
-          datetime: string
+          datetime: string | null
           emoji: string | null
+          end_at: string | null
           end_time: string | null
           id: string
+          start_at: string | null
           location_city: string | null
           location_department: string | null
           location_place: string | null
@@ -42,10 +44,12 @@ export type Database = {
           cover_url?: string | null
           createdby?: Json | null
           date?: string | null
-          datetime: string
+          datetime?: string | null
           emoji?: string | null
+          end_at?: string | null
           end_time?: string | null
           id?: string
+          start_at?: string | null
           location_city?: string | null
           location_department?: string | null
           location_place?: string | null
@@ -64,10 +68,12 @@ export type Database = {
           cover_url?: string | null
           createdby?: Json | null
           date?: string | null
-          datetime?: string
+          datetime?: string | null
           emoji?: string | null
+          end_at?: string | null
           end_time?: string | null
           id?: string
+          start_at?: string | null
           location_city?: string | null
           location_department?: string | null
           location_place?: string | null

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -15,10 +15,12 @@ export type Database = {
           cover_url: string | null
           createdby: Json | null
           date: string | null
-          datetime: string
+          datetime: string | null
           emoji: string | null
+          end_at: string | null
           end_time: string | null
           id: string
+          start_at: string | null
           location_city: string | null
           location_department: string | null
           location_place: string | null
@@ -35,10 +37,12 @@ export type Database = {
           cover_url?: string | null
           createdby?: Json | null
           date?: string | null
-          datetime: string
+          datetime?: string | null
           emoji?: string | null
+          end_at?: string | null
           end_time?: string | null
           id?: string
+          start_at?: string | null
           location_city?: string | null
           location_department?: string | null
           location_place?: string | null
@@ -55,10 +59,12 @@ export type Database = {
           cover_url?: string | null
           createdby?: Json | null
           date?: string | null
-          datetime?: string
+          datetime?: string | null
           emoji?: string | null
+          end_at?: string | null
           end_time?: string | null
           id?: string
+          start_at?: string | null
           location_city?: string | null
           location_department?: string | null
           location_place?: string | null

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -1,4 +1,4 @@
-import { daysOfWeek, monthNames } from "@/lib/utils";
+import { daysOfWeek, formatFrTime, getEventEnd, getEventStart } from "@/lib/utils";
 
 /**
  * Règle de récurrence hebdomadaire.
@@ -9,16 +9,17 @@ export type RecurrenceRule = {
   weekdays: number[]; // 0..6 (getDay)
   startDate: string; // YYYY-MM-DD
   endDate: string; // YYYY-MM-DD
-  startTime: string; // ex "16h30" (sert à construire le datetime français)
+  startTime: string; // "HH:MM" (heure de début, sert à construire start_at)
+  endTime?: string; // "HH:MM" (heure de fin optionnelle, sert à construire end_at)
 };
 
 /**
  * Champs partagés par toutes les occurrences d'une récurrence.
- * Ce sont les champs d'un événement hors `datetime`/`date` (calculés par occurrence).
+ * Ce sont les champs d'un événement hors horaire (start_at/end_at, calculés
+ * par occurrence à partir de la règle).
  */
 export type RecurringSharedFields = {
   name: string;
-  end_time?: string | null;
   location_place?: string | null;
   location_city?: string | null;
   location_department?: string | null;
@@ -48,22 +49,6 @@ function toISODate(date: Date): string {
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-}
-
-/**
- * Construit le datetime français attendu par l'app, ex :
- * "mercredi 21 mai 2025 à 16h30". L'heure y est incluse au format `16h30`
- * (cf. `formatTimeDisplay` dans utils.ts qui l'extrait par regex `\d{1,2}h\d{0,2}`).
- */
-export function buildDatetimeString(dateISO: string, startTime: string): string {
-  const d = parseISODate(dateISO);
-  const dayName = daysOfWeek[d.getDay()];
-  const dayNumber = d.getDate();
-  const monthName = monthNames[d.getMonth()];
-  const year = d.getFullYear();
-  const time = startTime?.trim();
-  const base = `${dayName} ${dayNumber} ${monthName} ${year}`;
-  return time ? `${base} à ${time}` : base;
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -155,13 +140,15 @@ export function describeRecurrence(
 
 /**
  * Décrit la récurrence d'un événement à partir de la règle jointe et de ses
- * horaires (l'heure de début est extraite du `datetime`). Retourne null si
- * l'événement n'est pas récurrent.
+ * horaires (lus depuis `start_at`/`end_at`). Retourne null si l'événement n'est
+ * pas récurrent.
  */
 export function describeRecurrenceFromEvent(
   event: {
+    start_at?: string | null;
+    end_at?: string | null;
+    date?: string | null;
     datetime?: string | null;
-    end_time?: string | null;
     recurrence?: { interval: number; weekdays: number[] } | null;
   },
   opts?: { includeTime?: boolean; withPrefix?: boolean },
@@ -169,14 +156,20 @@ export function describeRecurrenceFromEvent(
   if (!event.recurrence) return null;
   // Côté front, l'horaire est déjà affiché ailleurs : on peut l'omettre.
   const includeTime = opts?.includeTime !== false;
-  const startTime = includeTime ? (event.datetime?.match(/\d{1,2}h\d{0,2}/)?.[0] ?? null) : null;
-  const endTime = includeTime ? event.end_time : null;
+  let startTime: string | null = null;
+  let endTime: string | null = null;
+  if (includeTime) {
+    const start = getEventStart(event);
+    const end = getEventEnd(event);
+    startTime = start ? formatFrTime(start) : null;
+    endTime = end ? formatFrTime(end) : null;
+  }
   return describeRecurrence(event.recurrence, { startTime, endTime, withPrefix: opts?.withPrefix });
 }
 
 /**
  * Combine une règle de récurrence et les champs partagés en un tableau d'objets
- * prêts à insérer dans la table `events` (chacun avec son `date` et son `datetime`).
+ * prêts à insérer dans la table `events` (chacun avec ses `start_at`/`end_at`).
  * Les champs sont retournés tels quels ; la normalisation (ville/prix) et les
  * métadonnées (status, recurrence_id, updated_at) sont ajoutées par l'appelant.
  */
@@ -187,7 +180,7 @@ export function buildRecurringEvents(
   const dates = computeOccurrenceDates(rule);
   return dates.map((date) => ({
     ...shared,
-    date,
-    datetime: buildDatetimeString(date, rule.startTime),
+    start_at: `${date}T${rule.startTime}:00`,
+    end_at: rule.endTime ? `${date}T${rule.endTime}:00` : null,
   }));
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -73,33 +73,115 @@ export function getMonthNameShort(index: number): string {
   return monthNamesShort[index] || "";
 }
 
+/**
+ * Sous-ensemble des champs d'un événement nécessaires au calcul date/heure.
+ * Permet d'appeler les helpers depuis du code qui ne manipule qu'un événement
+ * partiel (ex : recurrence.ts).
+ */
+export type EventTimeFields = {
+  start_at?: string | null;
+  end_at?: string | null;
+  date?: string | null;
+  datetime?: string | null;
+  end_time?: string | null;
+};
+
+/**
+ * Parse un timestamp naïf Postgres (`timestamp` sans fuseau), ex
+ * "2025-05-21T16:30:00" ou "2025-05-21 16:30:00", en `Date` interprétée en
+ * heure LOCALE. On ne fait jamais `new Date(value)` directement, qui
+ * interpréterait une chaîne ISO sans `Z` de façon ambiguë selon le moteur.
+ */
+export function parseLocalDateTime(value?: string | null): Date | null {
+  if (!value) return null;
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (!m) return null;
+  const [, y, mo, d, h, mi, s] = m;
+  return new Date(
+    parseInt(y, 10), parseInt(mo, 10) - 1, parseInt(d, 10),
+    parseInt(h, 10), parseInt(mi, 10), s ? parseInt(s, 10) : 0, 0,
+  );
+}
+
+/**
+ * Date+heure de début d'un événement. Utilise `start_at` en priorité ; à défaut
+ * (données legacy non migrées) reconstruit depuis `date` + l'heure extraite du
+ * texte `datetime`. Retourne null si aucune date n'est disponible.
+ */
+export function getEventStart(event: EventTimeFields): Date | null {
+  const fromStartAt = parseLocalDateTime(event.start_at);
+  if (fromStartAt) return fromStartAt;
+  if (!event.date) return null;
+  const [year, month, day] = event.date.split("-").map((n) => parseInt(n, 10));
+  const t = event.datetime?.match(/(\d{1,2})h(\d{0,2})/);
+  // Midi par défaut quand aucune heure n'est connue (n'affecte que la partie date).
+  const hh = t ? parseInt(t[1], 10) : 12;
+  const mi = t && t[2] ? parseInt(t[2], 10) : 0;
+  return new Date(year, month - 1, day, hh, mi, 0, 0);
+}
+
+/** Date+heure de fin (optionnelle). */
+export function getEventEnd(event: EventTimeFields): Date | null {
+  return parseLocalDateTime(event.end_at);
+}
+
+/** Formate une heure en français : "16h30", ou "16h" pour une heure pile. */
+export function formatFrTime(date: Date): string {
+  const h = date.getHours();
+  const m = date.getMinutes();
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}`;
+}
+
+/** Libellé de date long en français : "mercredi 21 mai 2025". */
+export function formatFrDateLabel(date: Date): string {
+  return `${daysOfWeek[date.getDay()]} ${date.getDate()} ${monthNames[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+/**
+ * Libellé complet date + heure pour les tableaux (admin), ex
+ * "mercredi 21 mai 2025 à 16h30". Fallback sur le texte legacy `datetime`.
+ */
+export function formatEventDateTimeLabel(event: EventTimeFields): string {
+  const start = getEventStart(event);
+  if (!start) return event.datetime ?? "";
+  const time = formatTimeDisplay(event);
+  const label = formatFrDateLabel(start);
+  return time ? `${label} à ${time}` : label;
+}
+
 export function getDateParts(event: Event) {
-  if (!event.date) return { day: "", month: "", year: "" };
-  const [year, month, day] = event.date.split("-");
+  const d = getEventStart(event);
+  if (!d) return { day: "", month: "", year: "" };
   return {
-    day: parseInt(day, 10).toString().padStart(2, '0'),
-    month: monthNamesShort[parseInt(month, 10) - 1] || "",
-    year: year
+    day: d.getDate().toString().padStart(2, "0"),
+    month: monthNamesShort[d.getMonth()] || "",
+    year: d.getFullYear().toString(),
   };
 }
 
-export function formatTimeDisplay(event: Event) {
+export function formatTimeDisplay(event: EventTimeFields) {
+  const start = getEventStart(event);
+  // Chemin nominal : start_at est une vraie date+heure.
+  if (parseLocalDateTime(event.start_at) && start) {
+    const end = getEventEnd(event);
+    // 00:00 = heure non renseignée (events legacy backfillés) : on n'affiche rien.
+    if (start.getHours() === 0 && start.getMinutes() === 0 && !end) return "";
+    const startLabel = formatFrTime(start);
+    return end ? `${startLabel} — ${formatFrTime(end)}` : startLabel;
+  }
+  // Fallback legacy : extraction par regex sur le texte `datetime`.
   if (!event.datetime) return "";
-  // Les minutes sont optionnelles : on accepte « 14h » comme « 14h30 ».
   const timeMatch = event.datetime.match(/(\d{1,2}h\d{0,2})/);
   if (timeMatch) {
-    if (event.end_time) {
-      return `${timeMatch[1]} — ${event.end_time}`;
-    }
-    return timeMatch[1];
+    return event.end_time ? `${timeMatch[1]} — ${event.end_time}` : timeMatch[1];
   }
   return "";
 }
 
 export function isToday(event: Event) {
-  if (!event.date) return false;
+  const eventDate = getEventStart(event);
+  if (!eventDate) return false;
   const today = new Date();
-  const eventDate = new Date(event.date);
   return (
     today.getFullYear() === eventDate.getFullYear() &&
     today.getMonth() === eventDate.getMonth() &&

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -18,6 +18,7 @@ import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
 import { buildRecurringEvents, describeRecurrenceFromEvent, type RecurrenceRule, type RecurringSharedFields } from "@/lib/recurrence";
+import { formatEventDateTimeLabel } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -60,6 +61,8 @@ const AdminDashboard = () => {
   const emptyEvent: EventRow = {
     id: '',
     name: '',
+    start_at: null,
+    end_at: null,
     datetime: '',
     date: '',
     end_time: null,
@@ -120,8 +123,7 @@ const AdminDashboard = () => {
     // Super admin avec "Toutes les organisations" - pas de filtre
 
     query = query
-      .order('date', { ascending: false })
-      .order('datetime', { ascending: false });
+      .order('start_at', { ascending: false, nullsFirst: false });
 
     const { data, error } = await query;
     if (error) {
@@ -153,17 +155,15 @@ const AdminDashboard = () => {
     const today = new Date().toISOString().slice(0, 10); // format YYYY-MM-DD
     // Filtrer sur la date si on ne veut pas les événements passés
     if (!showPastEvents) {
-      query = query.gte('date', today).order('date', { ascending: true });
+      query = query.gte('start_at', today).order('start_at', { ascending: true, nullsFirst: false });
     } else {
-      query = query.lt('date', today).order('date', { ascending: false });
+      query = query.lt('start_at', today).order('start_at', { ascending: false, nullsFirst: false });
     }
-    query = query
-      .order('datetime', { ascending: false })
-      .range(from, to);
+    query = query.range(from, to);
     if (search) {
       const lower = debouncedSearch.toLowerCase();
       query = query.or(
-        `name.ilike.%${lower}%,datetime.ilike.%${lower}%,location_place.ilike.%${lower}%,location_city.ilike.%${lower}%,location_department.ilike.%${lower}%`
+        `name.ilike.%${lower}%,location_place.ilike.%${lower}%,location_city.ilike.%${lower}%,location_department.ilike.%${lower}%`
       );
     }
     const { data, error, count } = await query;
@@ -347,9 +347,8 @@ const AdminDashboard = () => {
       const { error: insertError } = await supabase
         .from('events')
         .insert({
-          datetime: eventData.datetime,
-          date: eventData.date || null,
-          end_time: eventData.end_time || null,
+          start_at: eventData.start_at || null,
+          end_at: eventData.end_at || null,
           name: eventData.name,
           location_place: eventData.location_place || null,
           location_city: eventData.location_city,
@@ -511,7 +510,7 @@ const AdminDashboard = () => {
               <TableBody>
                 {pendingEvents.map(event => (
                   <TableRow key={event.id}>
-                    <TableCell className="font-medium">{event.datetime}</TableCell>
+                    <TableCell className="font-medium">{formatEventDateTimeLabel(event)}</TableCell>
                     <TableCell>
                       <div className="max-w-xs">
                         <div className="flex items-center gap-2">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -80,7 +80,7 @@ const Index = () => {
         .from('events')
         .select('*, theme:theme_id(*), recurrence:recurrence_id(*)')
         .eq('status', 'accepted')
-        .gte('date', today); // Filtrer uniquement les événements futurs ou d'aujourd'hui
+        .gte('start_at', today); // Filtrer uniquement les événements futurs ou d'aujourd'hui
 
       // Filtrer selon les organisations de l'utilisateur
       if (contextUser && !isSuperAdmin && organizations.length > 0) {
@@ -96,10 +96,9 @@ const Index = () => {
       // Appliquer les filtres actifs (département, etc.) côté serveur
       futureQuery = applyFiltersToQuery(futureQuery, filterValues);
 
-      // Trier les événements futurs par date croissante
+      // Trier les événements futurs par date+heure croissante (start_at)
       futureQuery = futureQuery
-        .order('date', { nullsFirst: false })
-        .order('datetime');
+        .order('start_at', { nullsFirst: false });
 
       const { data, error } = await futureQuery;
 
@@ -157,7 +156,7 @@ const Index = () => {
       .from('events')
       .select('*, theme:theme_id(*)')
       .eq('status', 'accepted')
-      .lt('date', today); // Filtrer uniquement les événements passés
+      .lt('start_at', today); // Filtrer uniquement les événements passés
 
     // Filtrer selon les organisations de l'utilisateur
     if (contextUser && !isSuperAdmin && organizations.length > 0) {
@@ -173,10 +172,9 @@ const Index = () => {
     // Appliquer les filtres actifs (département, etc.) côté serveur
     pastQuery = applyFiltersToQuery(pastQuery, filterValues);
 
-    // Trier les événements passés par date décroissante (les plus récents en premier)
+    // Trier les événements passés par date+heure décroissante (les plus récents en premier)
     pastQuery = pastQuery
-      .order('date', { ascending: false, nullsFirst: false })
-      .order('datetime', { ascending: false })
+      .order('start_at', { ascending: false, nullsFirst: false })
       .limit(200); // Limiter à 200 événements passés pour éviter de surcharger
 
     const { data, error } = await pastQuery;

--- a/supabase/migrations/20260618000000_event_start_end_at.sql
+++ b/supabase/migrations/20260618000000_event_start_end_at.sql
@@ -1,0 +1,47 @@
+-- Dissociation date / heure des événements (ticket #11).
+--
+-- Historiquement l'horaire d'un événement ponctuel était éclaté entre :
+--   - `date`      (YYYY-MM-DD) : seule clé de tri fiable, pas toujours renseignée ;
+--   - `datetime`  (texte FR "mercredi 21 mai 2025 à 16h30") : date + heure mélangées,
+--                 l'heure devant être ré-extraite par regex côté app ;
+--   - `end_time`  (texte "19h00") : heure de fin optionnelle.
+-- Le tri par horaire était donc cassé (tri alphabétique : "14h30" < "9h00").
+--
+-- On introduit deux vraies colonnes `start_at` / `end_at` (timestamp sans fuseau,
+-- heure murale locale de Paris). Les anciennes colonnes sont conservées le temps
+-- de la transition (un DROP suivra dans une migration ultérieure).
+
+alter table public.events
+  add column if not exists start_at timestamp,
+  add column if not exists end_at timestamp;
+
+-- `datetime` (NOT NULL historiquement) n'est plus écrit par l'application : on
+-- lève la contrainte pour autoriser les inserts qui ne renseignent que start_at.
+alter table public.events
+  alter column datetime drop not null;
+
+-- Backfill de start_at : date + heure de début extraite du texte `datetime`.
+-- L'heure est au format "16h30" ou "16h" (minutes optionnelles) ; défaut 00:00.
+update public.events e
+set start_at = (
+  e.date::text || ' '
+  || lpad(coalesce((regexp_match(e.datetime, '(\d{1,2})h(\d{0,2})'))[1], '0'), 2, '0')
+  || ':'
+  || lpad(coalesce(nullif((regexp_match(e.datetime, '(\d{1,2})h(\d{0,2})'))[2], ''), '0'), 2, '0')
+  || ':00'
+)::timestamp
+where e.date is not null and e.start_at is null;
+
+-- Backfill de end_at : date + heure de fin (`end_time`), seulement si présente.
+update public.events e
+set end_at = (
+  e.date::text || ' '
+  || lpad((regexp_match(e.end_time, '(\d{1,2})h(\d{0,2})'))[1], 2, '0')
+  || ':'
+  || lpad(coalesce(nullif((regexp_match(e.end_time, '(\d{1,2})h(\d{0,2})'))[2], ''), '0'), 2, '0')
+  || ':00'
+)::timestamp
+where e.date is not null and e.end_time ~ '\d{1,2}h\d{0,2}' and e.end_at is null;
+
+-- Index pour le tri chronologique (date + heure en une seule clé).
+create index if not exists events_start_at_idx on public.events(start_at);


### PR DESCRIPTION
Remplace le champ texte fourre-tout datetime (et end_time) par deux vraies colonnes timestamp start_at/end_at (heure locale, sans fuseau), afin de trier les événements par date PUIS par horaire — l'objet du ticket #11.

- Migration: ajout start_at/end_at + backfill depuis date/datetime/end_time, index sur start_at, datetime rendu nullable (anciennes colonnes conservées en transition).
- Helpers utils: parseLocalDateTime, getEventStart/End, formatFrTime, formatFrDateLabel, formatEventDateTimeLabel; getDateParts/isToday/ formatTimeDisplay réécrits sur start_at avec fallback legacy.
- Récurrence: heures en HH:MM, buildRecurringEvents produit start_at/end_at, describeRecurrenceFromEvent lit les nouveaux champs.
- Formulaires admin & public: sélecteurs date + heure (début obligatoire, fin optionnelle) à la place du texte libre; RecurrenceFields en input time.
- Tri & filtres (Index, AdminDashboard): order/gte/lt sur start_at.
- Affichage (EventCard, EventList, EventsTable): dérivé de start_at.