### PR TITLE
Afficher les heures pleines en 16h00 (#38)

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -110,11 +110,11 @@ export function getEventEnd(event: EventTimeFields): Date | null {
   return parseLocalDateTime(event.end_at);
 }
 
-/** Formate une heure en français : "16h30", ou "16h" pour une heure pile. */
+/** Formate une heure en français : "16h30", ou "16h00" pour une heure pile. */
 export function formatFrTime(date: Date): string {
   const h = date.getHours();
   const m = date.getMinutes();
-  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}`;
+  return `${h}h${String(m).padStart(2, "0")}`;
 }
 
 /** Libellé de date long en français : "mercredi 21 mai 2025". */


### PR DESCRIPTION
Closes #38

## Quoi
`formatFrTime` affiche désormais toujours les minutes sur deux chiffres : `16h` → `16h00`, en cohérence avec l'affichage déjà existant des heures non rondes (`16h30`).

## Où
Une seule fonction modifiée dans [src/lib/utils.ts](src/lib/utils.ts) — le changement se propage automatiquement partout (cartes front, tableaux admin, libellés de récurrence) puisque tout le formatage d'heure y transite.

## Vérif
- `tsc --noEmit` ✅
- Aucun test ni snapshot ne dépendait de l'ancien format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)