### PR TITLE
Redesign 1/4 — Système de design : accent pêche

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,6 +33,11 @@
     --ring: 222.2 84% 4.9%;
 
     --radius: 0.5rem;
+
+    /* Accent pêche/corail des CTA — identique clair/sombre (#F2A98E / #ED9873 / #1B263B) */
+    --accent-peach: 16 79% 75%;
+    --accent-peach-hover: 18 77% 69%;
+    --accent-peach-foreground: 219 37% 17%;
   }
 
   .dark {

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -164,11 +164,7 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
                         asChild
                         variant="outline"
                         size="icon"
-                        className={
-                          theme === 'light'
-                            ? 'bg-[#fff7e6] text-[#1B263B] border-[#f3e0c7] hover:bg-[#ffe2b0] hover:text-[#1B263B] shadow-sm'
-                            : 'bg-white/10 text-[#faf3ec]'
-                        }
+                        className="bg-accent-peach text-accent-peach-foreground border-transparent hover:bg-accent-peach-hover hover:text-accent-peach-foreground shadow-sm"
                       >
                         <Link href="/admin">
                           <Shield size={22} />
@@ -183,11 +179,7 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
                 <Button
                   onClick={() => setIsProposalDialogOpen(true)}
                   variant="outline"
-                  className={
-                    theme === 'light'
-                      ? 'bg-[#fff7e6] text-[#1B263B] border-[#f3e0c7] hover:bg-[#ffe2b0] hover:text-[#1B263B] shadow-sm'
-                      : 'bg-white/10 text-[#faf3ec]'
-                  }
+                  className="bg-accent-peach text-accent-peach-foreground border-transparent hover:bg-accent-peach-hover hover:text-accent-peach-foreground shadow-sm font-medium"
                 >
                   Proposer un événement
                 </Button>

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -4,11 +4,9 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowUp } from "lucide-react";
-import { useTheme } from "@/components/ThemeProvider";
 
 const BackToTop = () => {
   const [isVisible, setIsVisible] = useState(false);
-  const { theme } = useTheme();
 
   // Show button when page is scrolled down
   useEffect(() => {
@@ -38,11 +36,7 @@ const BackToTop = () => {
   return (
     <Button
       onClick={scrollToTop}
-      className={`fixed bottom-8 right-8 z-50 rounded-full w-12 h-12 p-0 shadow-lg transition-all duration-300 hover:scale-110 ${
-        theme === 'light' 
-          ? 'bg-[#1B263B] text-[#faf3ec] hover:bg-[#243447]' 
-          : 'bg-[#faf3ec] text-[#1B263B] hover:bg-white/90'
-      }`}
+      className="fixed bottom-8 right-8 z-50 rounded-full w-12 h-12 p-0 shadow-lg transition-all duration-300 hover:scale-110 bg-accent-peach text-accent-peach-foreground hover:bg-accent-peach-hover"
       size="icon"
       aria-label="Retour vers le haut"
     >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,12 @@ export default {
         "ephemeride-light": "#243447", // Version légèrement plus claire
         "ephemeride-dark": "#162029", // Version plus sombre
         "ephemeride-foreground": "#ffffff",
+        // Accent pêche/corail des CTA (identique en clair et sombre).
+        "accent-peach": {
+          DEFAULT: "hsl(var(--accent-peach))",
+          hover: "hsl(var(--accent-peach-hover))",
+          foreground: "hsl(var(--accent-peach-foreground))",
+        },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
## Contexte

Première itération du redesign visuel d'ephemeride.link inspiré de la maquette ChatGPT. Cette PR pose **les tokens du système de design**, sans refonte structurelle (layout, cards et timeline arrivent dans les PR suivantes).

## Changements

- **Token d'accent pêche/corail** unifié clair + sombre :
  - Variables CSS `--accent-peach`, `--accent-peach-hover`, `--accent-peach-foreground` dans `globals.css` (`#F2A98E` / `#ED9873` / texte navy `#1B263B`).
  - Couleur Tailwind `accent-peach` (`DEFAULT`/`hover`/`foreground`).
- **Câblage sur les CTA existants** (pour que le token serve réellement) :
  - Bouton « Proposer un événement » et bouton admin (`home-client.tsx`).
  - Bouton retour-en-haut (`BackToTop.tsx`) → pastille pêche.

Aucune nouvelle fonctionnalité, 100 % visuel.

## Vérification

- `npm run lint` : 0 erreur (warnings `<img>` préexistants uniquement).
- `npm run build` : OK.
- Rendu vérifié (clair + sombre) : CTA pêche avec texte navy, contraste correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)