### PR TITLE
Redesign 2/4 — Layout & espaces

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -137,7 +137,7 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
         <TipeeeBanner />
 
         <header className={`py-4 px-4 md:px-8 transition-all duration-300 z-20 ${isHeaderSticky ? 'fixed top-0 left-0 right-0 dark:bg-ephemeride/95 light:bg-[#faf3ec]/95 shadow-md backdrop-blur-3xl dark:backdrop-blur-sm' : ''}`}>
-          <div className="max-w-4xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             <div className={`flex flex-col md:flex-row items-center justify-between transition-all duration-300 ${isHeaderSticky ? 'py-2' : 'py-4'}`}>
               <div className="flex justify-start">
                 <img
@@ -188,8 +188,8 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
           </div>
         </header>
 
-        <main className={`flex-1 container mx-auto px-4 md:px-8 py-8 ${isHeaderSticky ? 'mt-48 md:mt-40' : ''}`}>
-          <div className="max-w-4xl mx-auto">
+        <main className={`flex-1 container mx-auto px-4 md:px-8 py-8 md:py-12 ${isHeaderSticky ? 'mt-48 md:mt-40' : ''}`}>
+          <div className="max-w-6xl mx-auto">
             <EventList
               events={filteredEvents}
               pastEvents={filteredPastEvents}

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -8,7 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useTheme } from "@/components/ThemeProvider";
 import {
   ALL_VALUE,
   eventFilterDefinitions,
@@ -38,9 +37,6 @@ const EventFilters = ({
   onReset,
   definitions = eventFilterDefinitions,
 }: EventFiltersProps) => {
-  const { theme } = useTheme();
-  const isLight = theme === "light";
-
   // On ne propose un filtre que s'il existe au moins deux valeurs distinctes :
   // filtrer sur une unique valeur n'aurait aucun intérêt.
   const filters = definitions
@@ -53,10 +49,12 @@ const EventFilters = ({
   if (filters.length === 0) return null;
 
   // Pilule arrondie cohérente avec le redesign (cf. maquette).
-  const triggerClass = isLight
-    ? "rounded-full border-[#f3e0c7] bg-white text-[#1B263B] hover:bg-[#fff7e6]"
-    : "rounded-full border-white/15 bg-white/10 text-[#faf3ec] hover:bg-white/15";
-  const labelClass = isLight ? "text-[#1B263B]" : "text-[#faf3ec]";
+  // Style piloté par les variantes Tailwind `dark:` (classe posée sur <html>
+  // avant le paint) plutôt que par la valeur JS du thème, afin d'éviter le
+  // flash « select blanc » au chargement avant le montage du composant.
+  const triggerClass =
+    "rounded-full border-[#f3e0c7] bg-white text-[#1B263B] hover:bg-[#fff7e6] dark:border-white/15 dark:bg-white/10 dark:text-[#faf3ec] dark:hover:bg-white/15";
+  const labelClass = "text-[#1B263B] dark:text-[#faf3ec]";
 
   return (
     <div className="mb-10 flex flex-wrap items-end gap-4">

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -52,15 +52,16 @@ const EventFilters = ({
 
   if (filters.length === 0) return null;
 
+  // Pilule arrondie cohérente avec le redesign (cf. maquette).
   const triggerClass = isLight
-    ? "border-[#f3e0c7] bg-white text-[#1B263B]"
-    : "border-white/20 bg-white/10 text-[#faf3ec]";
+    ? "rounded-full border-[#f3e0c7] bg-white text-[#1B263B] hover:bg-[#fff7e6]"
+    : "rounded-full border-white/15 bg-white/10 text-[#faf3ec] hover:bg-white/15";
   const labelClass = isLight ? "text-[#1B263B]" : "text-[#faf3ec]";
 
   return (
     <div className="mb-10 flex flex-wrap items-end gap-4">
       {filters.map(({ definition, values: opts }) => (
-        <div key={definition.key} className="flex flex-col gap-1">
+        <div key={definition.key} className="flex flex-col gap-1.5">
           <span className={`text-sm font-medium ${labelClass}`}>
             {definition.label}
           </span>
@@ -70,7 +71,7 @@ const EventFilters = ({
               onChange({ ...values, [definition.key]: value })
             }
           >
-            <SelectTrigger className={`w-[240px] ${triggerClass}`}>
+            <SelectTrigger className={`w-[240px] transition-colors ${triggerClass}`}>
               <SelectValue placeholder={definition.allLabel} />
             </SelectTrigger>
             <SelectContent>
@@ -92,7 +93,7 @@ const EventFilters = ({
           variant="ghost"
           size="sm"
           onClick={onReset}
-          className={`gap-1 ${labelClass}`}
+          className={`gap-1 rounded-full ${labelClass}`}
         >
           <X className="h-4 w-4" />
           Réinitialiser


### PR DESCRIPTION
## Contexte

Deuxième itération du redesign. Empilée sur la PR #46 (système de design). GitHub re-ciblera automatiquement sur `main` après merge de #46.

Objectif : **aérer** la mise en page, le container étant trop étriqué sur desktop.

## Changements

- Wrappers header + main : `max-w-4xl` → **`max-w-6xl`** (1152 px).
- Rythme vertical du contenu principal augmenté (`py-8` → `py-8 md:py-12`).
- Filtre « Département » restylé en **pilule arrondie** (trigger + bouton réinitialiser), apparence seulement — logique de filtrage inchangée.

Aucune nouvelle fonctionnalité.

## Vérification

- `npm run lint` : 0 erreur.
- Rendu vérifié clair + sombre : container élargi, filtre en pilule, CTA pêche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)