### PR TITLE
Redesign 5/5 — Skeleton de chargement

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import type { Database } from "@/lib/database.types";
 type Event = Database["public"]["Tables"]["events"]["Row"];
 import EventCard from "./EventCard";
+import EventListSkeleton from "./EventListSkeleton";
 import { Button } from "@/components/ui/button";
 import { Share, Mail, MessageSquare, Send, ChevronDown, ChevronUp } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
@@ -31,6 +32,10 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([]);
   const [lastUpdated, setLastUpdated] = useState<string>("");
   const [isPastEventsOpen, setIsPastEventsOpen] = useState<boolean>(false);
+  // Faux tant que la liste « à venir » n'a pas été dérivée côté client : on
+  // affiche alors un skeleton (la dérivation se fait dans un effet pour utiliser
+  // le « aujourd'hui » local du visiteur).
+  const [ready, setReady] = useState(false);
   const { theme } = useTheme();
 
   // Formate la date de la dernière création/modification d'un événement
@@ -73,6 +78,7 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
     });
 
     setUpcomingEvents(upcoming);
+    setReady(true);
   }, [events]);
 
   // Déclencher le chargement des événements passés quand on ouvre la section
@@ -137,6 +143,10 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
   };
 
   const textColorClass = theme === "light" ? "text-[#1B263B]" : "text-[#faf3ec]";
+
+  // Premier rendu (serveur + hydratation) : la liste « à venir » n'est pas
+  // encore dérivée → on affiche le skeleton plutôt qu'un état vide qui clignote.
+  if (!ready) return <EventListSkeleton />;
 
   // Rail timeline : pastille colorée (couleur du jour) + date empilée, posée
   // sur une ligne verticale. Sticky pour les événements à venir.

--- a/src/components/EventListSkeleton.tsx
+++ b/src/components/EventListSkeleton.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * Skeleton de la liste d'événements, affiché pendant le bref instant où
+ * EventList dérive les événements à venir côté client (avant que le useEffect
+ * ne peuple la liste). Reproduit la structure du redesign : rail timeline +
+ * cards. Les teintes sont pilotées par les variantes Tailwind `dark:` (CSS,
+ * sans dépendre du thème JS) pour éviter tout flash.
+ */
+
+// Barre grise neutre, contrastée sur le fond comme sur les cards.
+const Bar = ({ className = "" }: { className?: string }) => (
+  <div className={`animate-pulse rounded bg-gray-200 dark:bg-white/10 ${className}`} />
+);
+
+const SkeletonCard = () => (
+  <div className="flex flex-col md:flex-row overflow-hidden rounded-2xl shadow-sm bg-white dark:bg-ephemeride-light">
+    {/* Emplacement de l'affiche */}
+    <div className="h-56 w-full md:h-auto md:w-56 flex-shrink-0 animate-pulse bg-gray-200 dark:bg-white/10" />
+    {/* Contenu */}
+    <div className="flex-1 p-6 space-y-3">
+      <Bar className="h-6 w-2/3" />
+      <Bar className="h-4 w-1/2" />
+      <Bar className="h-4 w-1/3" />
+      <div className="flex justify-end pt-6">
+        <Bar className="h-9 w-44 rounded-full" />
+      </div>
+    </div>
+  </div>
+);
+
+const SkeletonDayGroup = ({ cards }: { cards: number }) => (
+  <div className="mb-6 flex gap-4 md:gap-6">
+    {/* Rail timeline : pastille + date empilée */}
+    <div className="flex-shrink-0 w-20 md:w-28">
+      <div className="flex items-start gap-2">
+        <span className="mt-2 h-3.5 w-3.5 flex-shrink-0 rounded-full bg-gray-300 dark:bg-white/15" />
+        <div className="space-y-2">
+          <Bar className="h-3 w-14" />
+          <Bar className="h-8 w-10" />
+          <Bar className="h-3 w-12" />
+          <Bar className="h-3 w-10" />
+        </div>
+      </div>
+    </div>
+    {/* Colonne des cards */}
+    <div className="flex-1 min-w-0 space-y-4">
+      {Array.from({ length: cards }).map((_, i) => (
+        <SkeletonCard key={i} />
+      ))}
+    </div>
+  </div>
+);
+
+const EventListSkeleton = () => (
+  <div className="animate-in fade-in duration-300" aria-hidden="true">
+    {/* Compteur + dernière mise à jour */}
+    <div className="mb-8 space-y-2">
+      <Bar className="h-5 w-2/3 max-w-xl" />
+      <Bar className="h-4 w-1/2 max-w-md" />
+    </div>
+
+    {/* Filtre (pilule) */}
+    <Bar className="mb-10 h-10 w-[240px] rounded-full" />
+
+    {/* Titre « Événements à venir » */}
+    <Bar className="mb-8 h-8 w-64" />
+
+    {/* Séparateur de mois */}
+    <div className="my-8 flex items-center gap-4">
+      <div className="h-px flex-grow bg-gray-200 dark:bg-white/10" />
+      <Bar className="h-5 w-28" />
+      <div className="h-px flex-grow bg-gray-200 dark:bg-white/10" />
+    </div>
+
+    <SkeletonDayGroup cards={2} />
+    <SkeletonDayGroup cards={1} />
+  </div>
+);
+
+export default EventListSkeleton;


### PR DESCRIPTION
## Contexte

Itération bonus du redesign. Empilée sur la PR #49. GitHub re-ciblera sur `main` après merge des PR précédentes.

`EventList` dérive la liste des événements « à venir » dans un `useEffect` (volontairement côté client, pour utiliser le « aujourd'hui » **local** du visiteur et éviter un mismatch d'hydratation lié au fuseau). Conséquence : au tout premier rendu la liste est vide, ce qui produisait un bref état vide / clignotement avant que l'effet ne peuple la liste.

## Changements

- Nouveau composant `EventListSkeleton` reproduisant la structure du redesign : ligne de compteur, pilule de filtre, titre, séparateur de mois, puis **rail timeline** (pastille + date empilée) + **cards** (emplacement affiche large + lignes de texte + bouton arrondi).
- `EventList` affiche le skeleton tant que la liste « à venir » n'est pas dérivée (`ready`), puis bascule sur la vraie liste.
- Teintes pilotées par les variantes Tailwind `dark:` (CSS, posées sur `<html>` avant le paint) → pas de flash, cohérent avec le correctif du select.

Aucune nouvelle fonctionnalité métier.

## Vérification

- `npm run lint` : 0 erreur.
- HTML rendu serveur : le skeleton est présent (`animate-pulse`), l'état vide « Aucun événement » et la liste réelle ne sont plus rendus au premier paint (ils apparaissent après hydratation).

> Note : la capture d'écran headless n'a pas pu être produite ce run (limite de descripteurs de fichiers de l'environnement sur Chrome) ; vérification faite via le HTML SSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)