### PR TITLE
Nettoyer les noms de fichiers avant upload (#52)

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { useUserRoleContext } from "@/components/UserRoleProvider";
 import TipeeeSettingsCard from "@/components/settings/TipeeeSettingsCard";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { sanitizeFileName } from "@/lib/utils";
 
 type Theme = Database["public"]["Tables"]["themes"]["Row"];
 type ThemeFormValues = {
@@ -127,7 +128,7 @@ const SettingsAdmin = () => {
     let image_url = null;
     let image_url_light = null;
     if (selectedFile) {
-      const filePath = `themes/${Date.now()}_${selectedFile.name}`;
+      const filePath = `themes/${Date.now()}_${sanitizeFileName(selectedFile.name)}`;
       const { error: uploadError } = await supabase.storage.from('event-assets').upload(filePath, selectedFile, { upsert: true });
       if (!uploadError) {
         const { data: publicUrlData } = supabase.storage.from('event-assets').getPublicUrl(filePath);
@@ -135,7 +136,7 @@ const SettingsAdmin = () => {
       }
     }
     if (selectedFileLight) {
-      const filePathLight = `themes/${Date.now()}_${selectedFileLight.name}`;
+      const filePathLight = `themes/${Date.now()}_${sanitizeFileName(selectedFileLight.name)}`;
       const { error: uploadErrorLight } = await supabase.storage.from('event-assets').upload(filePathLight, selectedFileLight, { upsert: true });
       if (!uploadErrorLight) {
         const { data: publicUrlDataLight } = supabase.storage.from('event-assets').getPublicUrl(filePathLight);
@@ -212,7 +213,7 @@ const SettingsAdmin = () => {
     let image_url = editTheme.image_url;
     let image_url_light = editTheme.image_url_light;
     if (editFile) {
-      const filePath = `themes/${Date.now()}_${editFile.name}`;
+      const filePath = `themes/${Date.now()}_${sanitizeFileName(editFile.name)}`;
       const { error: uploadError } = await supabase.storage.from('event-assets').upload(filePath, editFile, { upsert: true });
       if (!uploadError) {
         const { data: publicUrlData } = supabase.storage.from('event-assets').getPublicUrl(filePath);
@@ -220,7 +221,7 @@ const SettingsAdmin = () => {
       }
     }
     if (editFileLight) {
-      const filePathLight = `themes/${Date.now()}_${editFileLight.name}`;
+      const filePathLight = `themes/${Date.now()}_${sanitizeFileName(editFileLight.name)}`;
       const { error: uploadErrorLight } = await supabase.storage.from('event-assets').upload(filePathLight, editFileLight, { upsert: true });
       if (!uploadErrorLight) {
         const { data: publicUrlDataLight } = supabase.storage.from('event-assets').getPublicUrl(filePathLight);

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useTheme } from "@/components/ThemeProvider";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
-import { formatCityName, formatPrice, getEventStart, getEventEnd } from "@/lib/utils";
+import { formatCityName, formatPrice, getEventStart, getEventEnd, sanitizeFileName } from "@/lib/utils";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Checkbox } from "@/components/ui/checkbox";
 import RecurrenceFields from "@/components/RecurrenceFields";
@@ -233,7 +233,7 @@ const EventForm = ({ event, onSave, onCancel, showValidationActions, themes, the
   const uploadCoverIfNeeded = async (currentCoverUrl: string | null): Promise<string | null | undefined> => {
     if (!coverFile) return currentCoverUrl;
     setIsUploading(true);
-    const filePath = `covers/${Date.now()}_${coverFile.name}`;
+    const filePath = `covers/${Date.now()}_${sanitizeFileName(coverFile.name)}`;
     const { error: uploadError } = await supabase.storage.from('event-assets').upload(filePath, coverFile, { upsert: true });
     setIsUploading(false);
     if (uploadError) {

--- a/src/components/EventProposalForm.tsx
+++ b/src/components/EventProposalForm.tsx
@@ -9,7 +9,7 @@ import { toast } from "@/hooks/use-toast";
 import { Card, CardContent } from "@/components/ui/card";
 import { supabase } from "@/integrations/supabase/client";
 import { useTheme } from "@/components/ThemeProvider";
-import { formatCityName, formatPrice } from "@/lib/utils";
+import { formatCityName, formatPrice, sanitizeFileName } from "@/lib/utils";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import RecurrenceFields from "@/components/RecurrenceFields";
 import { buildRecurringEvents, type RecurrenceRule } from "@/lib/recurrence";
@@ -92,7 +92,7 @@ const EventProposalForm = ({ onClose }: { onClose: () => void }) => {
   const uploadCoverIfNeeded = async (): Promise<string | null | undefined> => {
     if (!coverFile) return null;
     setIsUploading(true);
-    const filePath = `covers/${Date.now()}_${coverFile.name}`;
+    const filePath = `covers/${Date.now()}_${sanitizeFileName(coverFile.name)}`;
     const { error: uploadError } = await supabase.storage
       .from("event-assets")
       .upload(filePath, coverFile, { upsert: true });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,6 +33,28 @@ export function eventSlug(event: { id: string; name?: string | null }): string {
   return base ? `${base}-${event.id}` : event.id;
 }
 
+/**
+ * Nettoie un nom de fichier pour l'utiliser comme clé de stockage (Supabase
+ * Storage n'accepte pas les accents ni la plupart des caractères spéciaux).
+ * L'extension est préservée. Ex : "Société été.PNG" -> "societe-ete.png".
+ */
+export function sanitizeFileName(fileName?: string | null): string {
+  const name = (fileName || "").trim();
+  const lastDot = name.lastIndexOf(".");
+  const hasExt = lastDot > 0;
+  const base = hasExt ? name.slice(0, lastDot) : name;
+  const ext = hasExt ? name.slice(lastDot + 1) : "";
+
+  const cleanBase = slugify(base) || "fichier";
+  const cleanExt = ext
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+
+  return cleanExt ? `${cleanBase}.${cleanExt}` : cleanBase;
+}
+
 const TRAILING_UUID_RE =
   /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 


### PR DESCRIPTION
Les noms de fichiers étaient injectés bruts dans la clé de stockage Supabase, qui rejette accents et caractères spéciaux. Ajout d'un sanitizeFileName() (extension préservée) appliqué aux uploads d'affiches et de thèmes.