### PR TITLE
Vue calendrier publique « Constellation »

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Prérequis : **Node.js 20+** et **pnpm**.
 
 ```sh
 pnpm install
-pnpm dev          # serveur de dev (Turbopack) sur http://localhost:3000
+pnpm dev          # serveur de dev (Turbopack) sur http://localhost:8080
 ```
 
 Autres scripts :

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.30.2",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 8080",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint ."

--- a/src/app/admin/calendar/page.tsx
+++ b/src/app/admin/calendar/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  addDays,
+  addMonths,
+  endOfMonth,
+  endOfWeek,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from "date-fns";
+import EventForm from "@/components/EventForm";
+import { EventCalendar } from "@/components/calendar/EventCalendar";
+import { AdminLayout } from "@/components/AdminLayout";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { useTheme } from "@/components/ThemeProvider";
+import { useUserRoleContext } from "@/components/UserRoleProvider";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Card, CardContent } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { triggerRevalidate } from "@/lib/revalidate";
+import { toISODate } from "@/lib/utils";
+import type { Database } from "@/integrations/supabase/types";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+type ThemeRow = Database["public"]["Tables"]["themes"]["Row"];
+
+const AdminCalendar = () => {
+  const { isSuperAdmin, isLoading: userLoading, user } = useUserRoleContext();
+  const { theme } = useTheme();
+  const { toast } = useToast();
+
+  const [month, setMonth] = useState<Date>(() => startOfMonth(new Date()));
+  const [events, setEvents] = useState<EventRow[]>([]);
+  const [themes, setThemes] = useState<ThemeRow[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [currentEvent, setCurrentEvent] = useState<EventRow | undefined>(
+    undefined,
+  );
+
+  // Charger les thèmes une fois (réutilisés par EventForm).
+  useEffect(() => {
+    const fetchThemes = async () => {
+      const { data, error } = await supabase
+        .from("themes")
+        .select("*")
+        .order("name");
+      if (!error && data) setThemes(data);
+    };
+    fetchThemes();
+  }, []);
+
+  // Récupère les événements acceptés du mois visible (toutes organisations).
+  const fetchEvents = useCallback(async () => {
+    const from = toISODate(startOfWeek(startOfMonth(month), { weekStartsOn: 1 }));
+    const to = toISODate(
+      addDays(endOfWeek(endOfMonth(month), { weekStartsOn: 1 }), 1),
+    );
+    const { data, error } = await supabase
+      .from("events")
+      .select("*, theme:theme_id(*), recurrence:recurrence_id(*)")
+      .eq("status", "accepted")
+      .gte("start_at", from)
+      .lt("start_at", to)
+      .order("start_at", { ascending: true, nullsFirst: false });
+    if (!error && data) setEvents(data as EventRow[]);
+  }, [month]);
+
+  useEffect(() => {
+    if (userLoading || !isSuperAdmin || !user) return;
+    void fetchEvents();
+  }, [fetchEvents, isSuperAdmin, userLoading, user]);
+
+  // Gating : réservé aux super admins.
+  if (!userLoading && !isSuperAdmin) {
+    return (
+      <AdminLayout
+        title="Accès refusé"
+        subtitle="Cette page est réservée aux super administrateurs"
+      >
+        <Card>
+          <CardContent className="p-8 text-center">
+            <h2 className="text-2xl font-bold mb-2">Accès refusé</h2>
+            <p className="text-muted-foreground">
+              Vous n'avez pas les permissions nécessaires pour accéder à cette
+              page.
+            </p>
+          </CardContent>
+        </Card>
+      </AdminLayout>
+    );
+  }
+
+  const handleSelectEvent = (event: EventRow) => {
+    setCurrentEvent(event);
+    setShowForm(true);
+  };
+
+  return (
+    <AdminLayout title="Calendrier" subtitle="Vue calendrier des événements">
+      <EventCalendar
+        month={month}
+        events={events}
+        onPrevMonth={() => setMonth((m) => subMonths(m, 1))}
+        onNextMonth={() => setMonth((m) => addMonths(m, 1))}
+        onToday={() => setMonth(startOfMonth(new Date()))}
+        onSelectEvent={handleSelectEvent}
+      />
+
+      <Dialog open={showForm} onOpenChange={setShowForm}>
+        <DialogContent
+          className={`w-3/4 max-w-4xl mx-auto ${
+            theme === "light"
+              ? "bg-[#f8f8f6] text-ephemeride border-none"
+              : "bg-ephemeride-light text-ephemeride-foreground border-none"
+          }`}
+        >
+          <DialogHeader>
+            <DialogTitle>Modifier l'événement</DialogTitle>
+          </DialogHeader>
+          <EventForm
+            event={currentEvent}
+            themes={themes}
+            onSave={async (eventData) => {
+              try {
+                const mapped = {
+                  ...eventData,
+                  updated_at: new Date().toISOString(),
+                } as EventRow & { theme?: ThemeRow };
+                delete (mapped as { theme?: ThemeRow }).theme;
+                // Les colonnes UUID rejettent "" : convertir en null.
+                const clean = Object.fromEntries(
+                  Object.entries({ ...mapped, status: "accepted" }).map(
+                    ([key, value]) => [key, value === "" ? null : value],
+                  ),
+                ) as Database["public"]["Tables"]["events"]["Update"];
+                const { error } = await supabase
+                  .from("events")
+                  .update(clean)
+                  .eq("id", currentEvent?.id);
+                if (error) throw error;
+                setShowForm(false);
+                await fetchEvents();
+                void triggerRevalidate();
+                toast({
+                  title: "Événement mis à jour",
+                  description: "L'événement a été mis à jour avec succès.",
+                });
+                return true;
+              } catch {
+                toast({
+                  title: "Erreur de sauvegarde",
+                  description:
+                    "Une erreur est survenue lors de la sauvegarde de l'événement.",
+                  variant: "destructive",
+                });
+                return false;
+              }
+            }}
+            onCancel={() => setShowForm(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </AdminLayout>
+  );
+};
+
+export default function Page() {
+  return (
+    <ProtectedRoute>
+      <AdminCalendar />
+    </ProtectedRoute>
+  );
+}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -2,7 +2,9 @@
 
 import BackToTop from "@/components/BackToTop";
 import { TipeeeProvider, TipeeeBanner, TipeeeFooterLogo } from "@/components/TipeeeSupport";
+import CalendarView from "@/components/calendar/CalendarView";
 import EventList from "@/components/EventList";
+import EventFilters from "@/components/events/EventFilters";
 import EventProposalForm from "@/components/EventProposalForm";
 import { useTheme } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -10,12 +12,15 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { supabase } from "@/integrations/supabase/client";
-import { Shield } from "lucide-react";
+import { CalendarDays, List, Moon, Plus, Shield, SlidersHorizontal, Sun } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { formatFrDateLabel, formatFrTime, getEventStart } from "@/lib/utils";
+import { useDragToClose } from "@/hooks/use-drag-to-close";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useUserRoleContext } from "@/components/UserRoleProvider";
 import {
   applyFiltersToEvents,
+  hasActiveFilters,
   readFilterValues,
   writeFilterParams,
   type FilterValues,
@@ -35,16 +40,43 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
   const [isPastEventsLoaded, setIsPastEventsLoaded] = useState(false);
   const [isProposalDialogOpen, setIsProposalDialogOpen] = useState(false);
   const [isHeaderSticky, setIsHeaderSticky] = useState(false);
+  // Bascule entre la liste classique et la vue calendrier « Constellation ».
+  const [view, setView] = useState<"list" | "calendar">("list");
+  // Tiroir de filtres (mobile), ouvert depuis le menu du bas.
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+  // Détection d'un swipe vers le haut sur la barre pour « attraper » le tiroir.
+  const barTouchStartY = useRef<number | null>(null);
+  // Mesure de la hauteur réelle du menu mobile → variable CSS `--mobile-menu-h`,
+  // utilisée par les tiroirs pour s'aligner pile sur le haut du menu.
+  const mobileBarRef = useRef<HTMLElement>(null);
+  // Glissé vertical du tiroir de filtres (suivi du doigt) pour le refermer.
+  const { dragY: filtersDragY, handlers: filtersDragHandlers } = useDragToClose(() =>
+    setIsFiltersOpen(false),
+  );
   // Filtres : valeurs par défaut au rendu serveur, hydratées depuis l'URL après montage.
   const [filterValues, setFilterValues] = useState<FilterValues>(() =>
     readFilterValues(new URLSearchParams()),
   );
-  const { theme } = useTheme();
+  const { theme, toggleTheme } = useTheme();
   const { user: contextUser, isSuperAdmin, organizations, isLoading } = useUserRoleContext();
 
   // Au montage : lit les filtres portés par l'URL (partage / retour navigateur).
   useEffect(() => {
     setFilterValues(readFilterValues(new URLSearchParams(window.location.search)));
+  }, []);
+
+  // Expose la hauteur réelle du menu mobile (padding + safe-area inclus) en
+  // variable CSS, pour que les tiroirs s'arrêtent exactement au-dessus de lui.
+  useEffect(() => {
+    const el = mobileBarRef.current;
+    if (!el) return;
+    const setVar = () =>
+      document.documentElement.style.setProperty("--mobile-menu-h", `${el.offsetHeight}px`);
+    setVar();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(setVar);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   const handleFilterChange = (values: FilterValues) => {
@@ -130,23 +162,188 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
     [pastEvents, filterValues],
   );
 
+  // Nombre d'événements à venir (filtrés) — affiché dans le footer.
+  const upcomingCount = useMemo(() => {
+    const todayStr = new Date().toISOString().slice(0, 10);
+    return filteredEvents.filter((event) => {
+      const start = getEventStart(event);
+      if (!start) return false;
+      const pad = (n: number) => String(n).padStart(2, "0");
+      const startStr = `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())}`;
+      return startStr >= todayStr;
+    }).length;
+  }, [filteredEvents]);
+
+  // Date de dernière mise à jour, formatée en français.
+  const formattedLastUpdated = useMemo(() => {
+    if (!lastUpdatedAt) return "";
+    const updated = new Date(lastUpdatedAt);
+    if (Number.isNaN(updated.getTime())) return "";
+    return `${formatFrDateLabel(updated)} à ${formatFrTime(updated)}`;
+  }, [lastUpdatedAt]);
+
+  // Bascule Liste / Calendrier — placée dans le header (sticky) pour rester
+  // accessible en permanence sur desktop comme sur mobile.
+  const viewToggle = (
+    <div className="inline-flex rounded-full bg-foreground/5 p-1">
+      {(["list", "calendar"] as const).map((v) => {
+        const Icon = v === "list" ? List : CalendarDays;
+        return (
+          <button
+            key={v}
+            type="button"
+            onClick={() => setView(v)}
+            aria-pressed={view === v}
+            className={`flex items-center gap-2 rounded-full px-4 py-1.5 text-sm transition-colors ${
+              view === v
+                ? "bg-accent-peach text-accent-peach-foreground font-bold shadow-sm"
+                : "font-medium text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            {v === "list" ? "Liste" : "Calendrier"}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  // Barre de navigation fixe en bas d'écran (mobile uniquement) : les deux
+  // modes de vue (liste / agenda) encadrent un bouton « + » central pour
+  // proposer un événement ; le thème est accessible sur le côté. Le retour en
+  // haut reste un bouton flottant indépendant (cf. BackToTop).
+  const mobileBarItem =
+    "flex flex-col items-center gap-0.5 px-2 text-[10px] font-medium transition-colors";
+  const mobileBottomBar = (
+    <>
+      {/* Tiroir de filtres custom : émerge de sous le menu (translateY + easeIn),
+          coin supérieur arrondi, SANS overlay. En `pointer-events-none` quand il
+          est fermé → il ne bloque jamais le menu. Glissé vers le bas pour fermer. */}
+      <div
+        className={`md:hidden fixed inset-x-0 z-50 ${isFiltersOpen ? "" : "pointer-events-none"}`}
+        style={{ bottom: "var(--mobile-menu-h, 52px)" }}
+        aria-hidden={!isFiltersOpen}
+      >
+        <div
+          className="rounded-t-3xl border-t border-foreground/10 bg-background px-4 pb-8 pt-3 shadow-[0_-12px_40px_rgba(0,0,0,0.18)]"
+          style={{
+            transform: isFiltersOpen ? `translateY(${filtersDragY}px)` : "translateY(120%)",
+            transition: filtersDragY ? "none" : "transform 300ms ease-in",
+          }}
+          {...filtersDragHandlers}
+        >
+          <div className="mx-auto mb-3 h-1.5 w-12 rounded-full bg-muted" />
+          <div className="mb-4 text-center font-display text-lg font-bold">Filtres</div>
+          <EventFilters
+            options={filterOptions}
+            values={filterValues}
+            onChange={handleFilterChange}
+            onReset={handleFilterReset}
+          />
+        </div>
+      </div>
+
+      <nav
+        ref={mobileBarRef}
+        className="md:hidden fixed inset-x-0 bottom-0 z-[60] border-t dark:border-white/10 light:border-ephemeride/10 dark:bg-ephemeride/95 light:bg-[#faf3ec]/95 backdrop-blur-md pb-[env(safe-area-inset-bottom)]"
+        onTouchStart={(e) => {
+          barTouchStartY.current = e.touches[0].clientY;
+        }}
+        onTouchMove={(e) => {
+          // Swipe vers le haut sur la barre → on « tire » le tiroir de filtres.
+          if (barTouchStartY.current != null && barTouchStartY.current - e.touches[0].clientY > 28) {
+            setIsFiltersOpen(true);
+            barTouchStartY.current = null;
+          }
+        }}
+        onTouchEnd={() => {
+          barTouchStartY.current = null;
+        }}
+      >
+        <div className="relative flex items-end justify-center gap-7 px-3 pt-2 pb-2">
+          {/* Filtres — côté gauche */}
+          <button
+            type="button"
+            onClick={() => setIsFiltersOpen((open) => !open)}
+            aria-label="Filtres"
+            className={`${mobileBarItem} absolute bottom-2 left-3 ${isFiltersOpen ? "text-accent-peach" : "opacity-60"}`}
+          >
+            <span className="relative">
+              <SlidersHorizontal className="h-5 w-5" />
+              {hasActiveFilters(filterValues) && (
+                <span className="absolute -right-1.5 -top-1 h-2.5 w-2.5 rounded-full bg-red-500 ring-2 ring-[#faf3ec] dark:ring-ephemeride" />
+              )}
+            </span>
+            Filtres
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setView("list")}
+            aria-pressed={view === "list"}
+            className={`${mobileBarItem} ${view === "list" ? "text-accent-peach" : "opacity-60"}`}
+          >
+            <List className="h-5 w-5" />
+            Liste
+          </button>
+
+          {/* Bouton central « + » (proposer un événement), plus grand et surélevé */}
+          <button
+            type="button"
+            onClick={() => setIsProposalDialogOpen(true)}
+            aria-label="Proposer un événement"
+            className="-mt-8 flex h-16 w-16 items-center justify-center rounded-full bg-accent-peach text-accent-peach-foreground shadow-lg transition-transform hover:scale-105 active:scale-95"
+          >
+            <Plus className="h-7 w-7" />
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setView("calendar")}
+            aria-pressed={view === "calendar"}
+            className={`${mobileBarItem} ${view === "calendar" ? "text-accent-peach" : "opacity-60"}`}
+          >
+            <CalendarDays className="h-5 w-5" />
+            Agenda
+          </button>
+
+          {/* Bascule de thème — côté droit */}
+          <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label="Changer le thème"
+            className={`${mobileBarItem} absolute bottom-2 right-3 opacity-60`}
+          >
+            {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+            Thème
+          </button>
+        </div>
+      </nav>
+    </>
+  );
+
   return (
     <TipeeeProvider>
-      <div className="min-h-screen flex flex-col dark:bg-ephemeride light:bg-[#faf3ec]">
+      <div className="min-h-screen flex flex-col dark:bg-ephemeride light:bg-[#faf3ec] pb-20 md:pb-0">
         {/* Bandeau de soutien Tipeee, tout en haut (affiché si activé dans l'admin) */}
         <TipeeeBanner />
 
         <header className={`py-4 px-4 md:px-8 transition-all duration-300 z-20 ${isHeaderSticky ? 'fixed top-0 left-0 right-0 dark:bg-ephemeride/95 light:bg-[#faf3ec]/95 shadow-md backdrop-blur-3xl dark:backdrop-blur-sm' : ''}`}>
           <div className="max-w-6xl mx-auto">
-            <div className={`flex flex-col md:flex-row items-center justify-between transition-all duration-300 ${isHeaderSticky ? 'py-2' : 'py-4'}`}>
+            <div className={`flex flex-col md:flex-row items-center justify-between gap-3 md:gap-4 transition-all duration-300 ${isHeaderSticky ? 'py-2' : 'py-4'}`}>
               <div className="flex justify-start">
                 <img
                   src={theme === 'light' ? '/images/ephemeride-logo-lite.png' : '/images/ephemeride-logo-dark.png'}
                   alt="Ephemeride"
-                  className={`transition-all duration-300 ${isHeaderSticky ? 'h-20' : 'h-32 md:h-32'}`}
+                  className={`w-auto max-w-full object-contain transition-all duration-300 ${isHeaderSticky ? 'h-12 md:h-20' : 'h-16 md:h-32'}`}
                 />
               </div>
-              <div className="flex gap-4 items-center">
+
+              {/* Switch de vue dans le header (desktop) ; sur mobile il est dans
+                  le menu du bas. */}
+              <div className="hidden md:block">{viewToggle}</div>
+
+              <div className="hidden md:flex gap-4 items-center">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span tabIndex={0} className="outline-none focus:ring-2 focus:ring-ring rounded-md">
@@ -179,7 +376,7 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
                 <Button
                   onClick={() => setIsProposalDialogOpen(true)}
                   variant="outline"
-                  className="bg-accent-peach text-accent-peach-foreground border-transparent hover:bg-accent-peach-hover hover:text-accent-peach-foreground shadow-sm font-medium"
+                  className="rounded-full bg-accent-peach text-accent-peach-foreground border-transparent hover:bg-accent-peach-hover hover:text-accent-peach-foreground shadow-sm font-medium"
                 >
                   Proposer un événement
                 </Button>
@@ -188,24 +385,43 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
           </div>
         </header>
 
-        <main className={`flex-1 container mx-auto px-4 md:px-8 py-8 md:py-12 ${isHeaderSticky ? 'mt-48 md:mt-40' : ''}`}>
+        <main className={`flex-1 container mx-auto px-4 md:px-8 py-8 md:py-12 ${isHeaderSticky ? 'mt-32 md:mt-40' : ''}`}>
           <div className="max-w-6xl mx-auto">
-            <EventList
-              events={filteredEvents}
-              pastEvents={filteredPastEvents}
-              onLoadPastEvents={fetchPastEvents}
-              lastUpdatedAt={lastUpdatedAt}
-              filterOptions={filterOptions}
-              filterValues={filterValues}
-              onFilterChange={handleFilterChange}
-              onFilterReset={handleFilterReset}
-            />
+            {/* Filtres (desktop) — partagés par les vues Liste et Calendrier.
+                Sur mobile, ils sont accessibles via le tiroir du menu du bas. */}
+            <div className="hidden md:block">
+              <EventFilters
+                options={filterOptions}
+                values={filterValues}
+                onChange={handleFilterChange}
+                onReset={handleFilterReset}
+              />
+            </div>
+
+            {view === "list" ? (
+              <EventList
+                events={filteredEvents}
+                pastEvents={filteredPastEvents}
+                onLoadPastEvents={fetchPastEvents}
+              />
+            ) : (
+              <CalendarView filterValues={filterValues} />
+            )}
           </div>
         </main>
 
         <footer className="border-t border-white/10 py-6 px-4 md:px-8 dark:border-white/10 light:border-ephemeride/10">
-          <div className="container mx-auto text-center">
+          <div className="container mx-auto text-center space-y-1">
+            {/* Compteur + dernière mise à jour (déplacés depuis le haut de page). */}
             <p className="text-sm font-normal opacity-70">
+              {upcomingCount} événements sont recensés au moment où vous consultez cette page
+            </p>
+            {formattedLastUpdated && (
+              <p className="text-sm font-normal opacity-70">
+                <span className="underline font-medium">dernière mise à jour</span> : {formattedLastUpdated}
+              </p>
+            )}
+            <p className="text-sm font-normal opacity-70 pt-2">
               L'AGENDA CULTUREL ET CITOYEN DU VIGNOBLE NANTAIS
             </p>
             {/* Logo Tipeee cliquable (affiché seulement si une URL est configurée) */}
@@ -222,8 +438,12 @@ const HomeClient = ({ initialEvents, lastUpdatedAt, filterOptions }: HomeClientP
           </DialogContent>
         </Dialog>
 
-        {/* Add Back to Top button */}
+        {/* Bouton flottant « retour en haut » (positionné au-dessus de la barre
+            du bas sur mobile) */}
         <BackToTop />
+
+        {/* Menu fixe en bas d'écran (mobile uniquement) */}
+        {mobileBottomBar}
       </div>
     </TipeeeProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,15 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Bricolage_Grotesque } from "next/font/google";
 import { Providers } from "./providers";
 
 const inter = Inter({ subsets: ["latin"], display: "swap" });
+// Police d'affichage (titres de mois, numéros de la constellation du calendrier).
+const bricolage = Bricolage_Grotesque({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-display",
+});
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://ephemeride.app";
 
@@ -28,7 +34,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="fr" suppressHydrationWarning>
+    <html lang="fr" suppressHydrationWarning className={bricolage.variable}>
       <body className={inter.className}>
         <Providers>{children}</Providers>
       </body>

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -80,6 +80,12 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({
     },
     ...(isSuperAdmin ? [
       {
+        href: '/admin/calendar',
+        icon: Calendar,
+        label: 'Calendrier',
+        description: 'Vue calendrier des événements'
+      },
+      {
         href: '/admin/settings',
         icon: Settings,
         label: 'Paramètres',

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -36,7 +36,7 @@ const BackToTop = () => {
   return (
     <Button
       onClick={scrollToTop}
-      className="fixed bottom-8 right-8 z-50 rounded-full w-12 h-12 p-0 shadow-lg transition-all duration-300 hover:scale-110 bg-accent-peach text-accent-peach-foreground hover:bg-accent-peach-hover"
+      className="fixed bottom-24 right-6 md:bottom-8 md:right-8 z-50 rounded-full w-12 h-12 p-0 shadow-lg transition-all duration-300 hover:scale-110 bg-accent-peach text-accent-peach-foreground hover:bg-accent-peach-hover"
       size="icon"
       aria-label="Retour vers le haut"
     >

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -10,55 +10,21 @@ import { Share, Mail, MessageSquare, Send, ChevronDown, ChevronUp } from "lucide
 import { useTheme } from "@/components/ThemeProvider";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { daysOfWeek, monthNames, monthNamesShort, getDateBlockColor, getEventStart } from "@/lib/utils";
-import EventFilters from "@/components/events/EventFilters";
-import type { FilterValues } from "@/lib/eventFilters";
 
 interface EventListProps {
   events: Event[];
   pastEvents?: Event[];
   onLoadPastEvents?: () => void;
-  lastUpdatedAt?: string | null;
-  /** Options disponibles par filtre (chargées en amont, indépendamment des filtres actifs). */
-  filterOptions: Record<string, string[]>;
-  /** Valeurs de filtre courantes (portées par l'URL). */
-  filterValues: FilterValues;
-  /** Met à jour les filtres. */
-  onFilterChange: (values: FilterValues) => void;
-  /** Réinitialise les filtres. */
-  onFilterReset: () => void;
 }
 
-const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, filterOptions, filterValues, onFilterChange, onFilterReset }: EventListProps) => {
+const EventList = ({ events, pastEvents = [], onLoadPastEvents }: EventListProps) => {
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([]);
-  const [lastUpdated, setLastUpdated] = useState<string>("");
   const [isPastEventsOpen, setIsPastEventsOpen] = useState<boolean>(false);
   // Faux tant que la liste « à venir » n'a pas été dérivée côté client : on
   // affiche alors un skeleton (la dérivation se fait dans un effet pour utiliser
   // le « aujourd'hui » local du visiteur).
   const [ready, setReady] = useState(false);
   const { theme } = useTheme();
-
-  // Formate la date de la dernière création/modification d'un événement
-  useEffect(() => {
-    if (!lastUpdatedAt) {
-      setLastUpdated("");
-      return;
-    }
-
-    const updated = new Date(lastUpdatedAt);
-    if (Number.isNaN(updated.getTime())) {
-      setLastUpdated("");
-      return;
-    }
-
-    const dayName = daysOfWeek[updated.getDay()];
-    const day = updated.getDate();
-    const month = monthNames[updated.getMonth()];
-    const year = updated.getFullYear();
-    const hours = updated.getHours().toString().padStart(2, '0');
-    const minutes = updated.getMinutes().toString().padStart(2, '0');
-    setLastUpdated(`${dayName} ${day} ${month} ${year} à ${hours}h${minutes}`);
-  }, [lastUpdatedAt]);
 
   // Filter events into upcoming based on the current date
   // Les événements passés sont maintenant passés directement en props
@@ -193,13 +159,11 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
 
   return (
     <div>
-      {/* Events Count and Last Updated Section - Before upcoming events heading */}
-      <div className={`text-lg font-normal opacity-70 mb-8 space-y-1 ${textColorClass}`}>
-        <p>{upcomingEvents.length} événements sont recensés au moment où vous consultez cette page</p>
-        <p><span className="underline font-medium">dernière mise à jour</span> : {lastUpdated}</p>
-        
-        {/* Social sharing buttons */}
-        <div className="flex space-x-3 pt-3">
+      {/* Boutons de partage du site — masqués pour le moment (conservés dans le
+          code ; réactiver en remplaçant `false` par `true`). */}
+      {false && (
+      <div className={`mb-8 ${textColorClass}`}>
+        <div className="flex space-x-3">
           <Button 
             variant="outline" 
             size="icon" 
@@ -242,19 +206,10 @@ const EventList = ({ events, pastEvents = [], onLoadPastEvents, lastUpdatedAt, f
           </Button>
         </div>
       </div>
-      
-      {/* Barre de filtres (extensible : voir src/lib/eventFilters.ts) */}
-      <EventFilters
-        options={filterOptions}
-        values={filterValues}
-        onChange={onFilterChange}
-        onReset={onFilterReset}
-      />
+      )}
 
       {/* Upcoming Events Section */}
       <div className="space-y-8 mb-12">
-        <h2 className={`text-2xl font-semibold mb-8 ${textColorClass}`}>Événements à venir</h2>
-
         {upcomingEvents.length === 0 && (
           <p className={`opacity-70 ${textColorClass}`}>
             Aucun événement à venir ne correspond à votre recherche.

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -15,8 +15,8 @@ export function ThemeToggle() {
       onClick={toggleTheme}     
       className={
         theme === 'light'
-          ? 'bg-[#fff7e6] text-[#1B263B] border-[#f3e0c7] hover:bg-[#ffe2b0] hover:text-[#1B263B] shadow-sm'
-          : 'bg-white/10 text-[#faf3ec]'
+          ? 'rounded-full bg-[#fff7e6] text-[#1B263B] border-[#f3e0c7] hover:bg-[#ffe2b0] hover:text-[#1B263B] shadow-sm'
+          : 'rounded-full bg-white/10 text-[#faf3ec]'
       }
     >
       {theme === 'light' ? (

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { addMonths, startOfMonth, subMonths } from "date-fns";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import type { Database } from "@/integrations/supabase/types";
+import { supabase } from "@/integrations/supabase/client";
+import { applyFiltersToEvents, type FilterValues } from "@/lib/eventFilters";
+import { getEventStart, monthNames, toISODate } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useDragToClose } from "@/hooks/use-drag-to-close";
+import ConstellationMonth from "@/components/calendar/ConstellationMonth";
+import DayDetailPanel from "@/components/calendar/DayDetailPanel";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+const EVENT_SELECT = "*, theme:theme_id(*), recurrence:recurrence_id(*)";
+
+interface CalendarViewProps {
+  /** Filtres actifs de la home (ex : Département), appliqués à la vue. */
+  filterValues: FilterValues;
+}
+
+/** Reconstruit une `Date` locale depuis une clé `YYYY-MM-DD`. */
+function dateFromKey(key: string): Date {
+  const [y, m, d] = key.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * Vue calendrier publique « Constellation ». Charge les événements acceptés du
+ * mois visible, les regroupe par jour, et affiche soit deux volets côte à côte
+ * (desktop), soit la constellation + un bottom sheet au tap d'un jour (mobile).
+ */
+const CalendarView = ({ filterValues }: CalendarViewProps) => {
+  const isMobile = useIsMobile();
+  const [month, setMonth] = useState<Date>(() => startOfMonth(new Date()));
+  const [events, setEvents] = useState<EventRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  // Glissé vertical du tiroir (suivi du doigt) pour le refermer.
+  const { dragY: sheetDragY, handlers: dayDragHandlers } = useDragToClose(() =>
+    setDrawerOpen(false),
+  );
+
+  const fetchMonth = useCallback(async () => {
+    setLoading(true);
+    const from = toISODate(startOfMonth(month));
+    const to = toISODate(addMonths(startOfMonth(month), 1));
+    const { data, error } = await supabase
+      .from("events")
+      .select(EVENT_SELECT)
+      .eq("status", "accepted")
+      .gte("start_at", from)
+      .lt("start_at", to)
+      .order("start_at", { ascending: true, nullsFirst: false });
+
+    if (error) {
+      console.error("Erreur lors du chargement du calendrier :", error);
+      setEvents([]);
+    } else {
+      setEvents((data || []) as EventRow[]);
+    }
+    setLoading(false);
+  }, [month]);
+
+  useEffect(() => {
+    fetchMonth();
+  }, [fetchMonth]);
+
+  // Regroupe les événements (filtrés) par jour, triés par heure de début.
+  const eventsByDay = useMemo(() => {
+    const filtered = applyFiltersToEvents(events as Record<string, unknown>[], filterValues) as EventRow[];
+    const map = new Map<string, EventRow[]>();
+    for (const event of filtered) {
+      const start = getEventStart(event);
+      if (!start) continue;
+      const key = toISODate(start);
+      const list = map.get(key);
+      if (list) list.push(event);
+      else map.set(key, [event]);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => (getEventStart(a)?.getTime() ?? 0) - (getEventStart(b)?.getTime() ?? 0));
+    }
+    return map;
+  }, [events, filterValues]);
+
+  const totalCount = useMemo(
+    () => Array.from(eventsByDay.values()).reduce((sum, list) => sum + list.length, 0),
+    [eventsByDay],
+  );
+
+  // Jour sélectionné par défaut (desktop) : aujourd'hui s'il a des événements,
+  // sinon le premier jour du mois qui en a.
+  useEffect(() => {
+    if (isMobile) return;
+    const todayKey = toISODate(new Date());
+    const validKey =
+      selectedKey && eventsByDay.has(selectedKey) ? selectedKey : null;
+    if (validKey) return;
+    let next: string | null = null;
+    if (eventsByDay.has(todayKey)) {
+      next = todayKey;
+    } else {
+      const keys = Array.from(eventsByDay.keys()).sort();
+      next = keys[0] ?? null;
+    }
+    setSelectedKey(next);
+  }, [eventsByDay, isMobile, selectedKey]);
+
+  const handleSelectDay = (key: string) => {
+    setSelectedKey(key);
+    if (isMobile) setDrawerOpen(true);
+  };
+
+  const goToMonth = (next: Date) => {
+    setSelectedKey(null);
+    setMonth(startOfMonth(next));
+  };
+
+  const selectedDate = selectedKey ? dateFromKey(selectedKey) : null;
+  const selectedEvents = selectedKey ? eventsByDay.get(selectedKey) ?? [] : [];
+
+  const monthTitle = `${monthNames[month.getMonth()]} ${month.getFullYear()}`;
+
+  const navButtons = (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        aria-label="Mois précédent"
+        onClick={() => goToMonth(subMonths(month, 1))}
+        className="flex h-9 w-9 items-center justify-center rounded-full border border-foreground/10 transition-colors hover:bg-foreground/5"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="Mois suivant"
+        onClick={() => goToMonth(addMonths(month, 1))}
+        className="flex h-9 w-9 items-center justify-center rounded-full border border-foreground/10 transition-colors hover:bg-foreground/5"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+
+  // ---------- Rendu mobile ----------
+  if (isMobile) {
+    return (
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-baseline gap-2">
+            <span className="font-display text-3xl font-extrabold leading-none">
+              {monthNames[month.getMonth()]}
+            </span>
+            <span className="text-sm text-muted-foreground">{month.getFullYear()}</span>
+          </div>
+          {navButtons}
+        </div>
+
+        <ConstellationMonth
+          month={month}
+          eventsByDay={eventsByDay}
+          selectedKey={selectedKey}
+          onSelectDay={handleSelectDay}
+          size="mobile"
+        />
+
+        {/* Tiroir des événements du jour (custom, cohérent avec le tiroir filtres) :
+            émerge de sous le menu, s'arrête au-dessus de la barre, sans overlay
+            bloquant ; en `pointer-events-none` quand fermé. Glissé vers le bas
+            pour fermer. */}
+        <div
+          className={`fixed inset-x-3 z-50 ${drawerOpen ? "" : "pointer-events-none"}`}
+          style={{ bottom: "var(--mobile-menu-h, 52px)" }}
+          aria-hidden={!drawerOpen}
+        >
+          <div
+            className="flex max-h-[70vh] flex-col rounded-t-3xl border border-foreground/10 bg-background px-4 pb-6 pt-3 shadow-[0_-12px_40px_rgba(0,0,0,0.18)]"
+            style={{
+              transform: drawerOpen ? `translateY(${sheetDragY}px)` : "translateY(120%)",
+              transition: sheetDragY ? "none" : "transform 300ms ease-in",
+            }}
+          >
+            {/* Poignée + fermeture : zone de glissé pour refermer le tiroir. */}
+            <div
+              className="relative shrink-0 cursor-grab pb-1 active:cursor-grabbing"
+              {...dayDragHandlers}
+            >
+              <div className="mx-auto h-1.5 w-12 rounded-full bg-muted" />
+              <button
+                type="button"
+                onClick={() => setDrawerOpen(false)}
+                aria-label="Fermer"
+                className="absolute right-0 top-0 rounded-full p-1 text-muted-foreground hover:bg-foreground/5"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            {selectedDate && (
+              <div className="overflow-y-auto pt-2">
+                <DayDetailPanel
+                  date={selectedDate}
+                  events={selectedEvents}
+                  size="mobile"
+                  onChanged={fetchMonth}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------- Rendu desktop ----------
+  return (
+    <div>
+      {/* Barre de contrôles */}
+      <div className="mb-5 flex items-center gap-4">
+        <span className="font-display text-2xl font-extrabold">{monthTitle}</span>
+        {navButtons}
+        <span className="text-sm text-muted-foreground">
+          {loading ? "Chargement…" : `${totalCount} événement${totalCount > 1 ? "s" : ""}`}
+        </span>
+      </div>
+
+      {/* Grille à deux colonnes égales (50-50), indépendante du contenu :
+          `min-w-0` empêche le texte des cartes d'élargir le volet de droite. */}
+      <div className="grid grid-cols-2 gap-7">
+        {/* Volet calendrier */}
+        <div className="min-w-0 rounded-3xl bg-white p-6 shadow-sm dark:bg-ephemeride-light">
+          <ConstellationMonth
+            month={month}
+            eventsByDay={eventsByDay}
+            selectedKey={selectedKey}
+            onSelectDay={handleSelectDay}
+            size="desktop"
+          />
+        </div>
+
+        {/* Volet détail du jour */}
+        <div className="min-w-0">
+          {selectedDate ? (
+            <DayDetailPanel
+              date={selectedDate}
+              events={selectedEvents}
+              size="desktop"
+              onChanged={fetchMonth}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center rounded-3xl border border-dashed border-foreground/10 p-8 text-center text-sm text-muted-foreground">
+              {loading ? "Chargement…" : "Aucun événement ce mois-ci."}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CalendarView;

--- a/src/components/calendar/ConstellationMonth.tsx
+++ b/src/components/calendar/ConstellationMonth.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getDaysInMonth, isSameDay, startOfMonth } from "date-fns";
+import type { Database } from "@/integrations/supabase/types";
+import { useTheme } from "@/components/ThemeProvider";
+import { toISODate } from "@/lib/utils";
+import { ACCENT, hexA, weekdayColor } from "@/lib/colors";
+import {
+  WEEKDAY_LETTER,
+  WEEKDAY_SHORT,
+  WEEK_ORDER,
+  mondayOffset,
+} from "@/components/calendar/weekdayColors";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+type Size = "mobile" | "desktop";
+
+interface ConstellationMonthProps {
+  month: Date;
+  eventsByDay: Map<string, EventRow[]>;
+  selectedKey: string | null;
+  onSelectDay: (key: string, day: Date, events: EventRow[]) => void;
+  size?: Size;
+}
+
+// Taille des bulles exprimée en FRACTION de la largeur de colonne (mesurée),
+// selon le nombre d'événements (1 → 5+). Plafonnée à 0,9 pour toujours laisser
+// un peu d'air entre les bulles → jamais de chevauchement, quelle que soit la
+// largeur du volet (mobile, tablette, desktop).
+const SIZE_FRACTION: Record<number, number> = { 1: 0.46, 2: 0.6, 3: 0.72, 4: 0.82, 5: 0.9 };
+
+interface Cell {
+  key: string | null;
+  date: Date | null;
+  day: number;
+  count: number;
+  color: string;
+  isToday: boolean;
+}
+
+/**
+ * Grille mensuelle « Constellation » : chaque jour est une bulle colorée selon
+ * le jour de la semaine et dimensionnée selon le nombre d'événements ce jour-là.
+ * Composant purement présentationnel — les données et la sélection viennent du
+ * parent (`CalendarView`).
+ */
+const ConstellationMonth = ({
+  month,
+  eventsByDay,
+  selectedKey,
+  onSelectDay,
+  size = "desktop",
+}: ConstellationMonthProps) => {
+  const { theme } = useTheme();
+  const isDark = theme === "dark";
+  const big = size === "desktop";
+
+  // Largeur de colonne mesurée (grille / 7), pour dimensionner les bulles
+  // proportionnellement au volet réel.
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [cellWidth, setCellWidth] = useState(0);
+  useEffect(() => {
+    const el = gridRef.current;
+    if (!el) return;
+    const update = () => setCellWidth(el.clientWidth / 7);
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Largeur de colonne effective (fallback avant la première mesure) et hauteur
+  // de case dérivée (cases quasi carrées, bornées).
+  const cw = cellWidth || (big ? 78 : 46);
+  const cellHeight = Math.round(Math.min(Math.max(cw, big ? 56 : 46), big ? 100 : 64));
+
+  const cells = useMemo<Cell[]>(() => {
+    const first = startOfMonth(month);
+    const y = first.getFullYear();
+    const m = first.getMonth();
+    const daysInMonth = getDaysInMonth(first);
+    const offset = mondayOffset(first.getDay());
+    const total = Math.ceil((offset + daysInMonth) / 7) * 7;
+    const today = new Date();
+
+    const out: Cell[] = [];
+    for (let i = 0; i < total; i++) {
+      const day = i - offset + 1;
+      const inMonth = day >= 1 && day <= daysInMonth;
+      if (!inMonth) {
+        out.push({ key: null, date: null, day: 0, count: 0, color: "", isToday: false });
+        continue;
+      }
+      const date = new Date(y, m, day);
+      const key = toISODate(date);
+      const count = eventsByDay.get(key)?.length ?? 0;
+      out.push({
+        key,
+        date,
+        day,
+        count,
+        color: weekdayColor(date),
+        isToday: isSameDay(date, today),
+      });
+    }
+    return out;
+  }, [month, eventsByDay]);
+
+  const headers = WEEK_ORDER.map((gd) => (big ? WEEKDAY_SHORT[gd] : WEEKDAY_LETTER[gd]));
+
+  return (
+    <div>
+      {/* En-têtes de jours */}
+      <div className="grid grid-cols-7 px-2 pb-1">
+        {headers.map((label, i) => (
+          <div
+            key={i}
+            className="text-center font-bold uppercase tracking-wide text-[11px] opacity-40"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Grille des bulles */}
+      <div ref={gridRef} className="grid grid-cols-7">
+        {cells.map((cell, i) => {
+          if (!cell.key || !cell.date) {
+            return (
+              <div
+                key={i}
+                className="flex items-center justify-center"
+                style={{ height: cellHeight }}
+              >
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    background: "transparent",
+                  }}
+                />
+              </div>
+            );
+          }
+
+          const { count, color, isToday, key, date } = cell;
+          const interactive = count > 0;
+          const selected = selectedKey === key;
+          const maxBubble = cellHeight * 0.86;
+          const bubbleSize =
+            count === 0
+              ? Math.min(Math.max(cw * 0.18, 6), big ? 12 : 8)
+              : Math.min(cw * (SIZE_FRACTION[Math.min(count, 5)] ?? SIZE_FRACTION[5]), maxBubble);
+
+          const ringWidth = big ? 2.5 : 2;
+          const numberSize = Math.max(10, Math.round(bubbleSize * 0.4));
+
+          return (
+            <div
+              key={i}
+              className="relative flex items-center justify-center"
+              style={{ height: cellHeight }}
+            >
+              {/* Anneau pointillé du jour sélectionné (desktop surtout) */}
+              {selected && (
+                <span
+                  aria-hidden
+                  className="absolute rounded-full"
+                  style={{
+                    width: bubbleSize + 10,
+                    height: bubbleSize + 10,
+                    border: `2px dashed ${ACCENT}`,
+                    opacity: 0.9,
+                  }}
+                />
+              )}
+              <button
+                type="button"
+                disabled={!interactive}
+                onClick={() => interactive && onSelectDay(key, date, eventsByDay.get(key) ?? [])}
+                aria-label={
+                  interactive
+                    ? `${count} événement${count > 1 ? "s" : ""} le ${date.getDate()}`
+                    : undefined
+                }
+                aria-pressed={selected}
+                className={`relative z-[1] flex items-center justify-center transition-transform ${
+                  interactive ? "cursor-pointer hover:scale-105" : "cursor-default"
+                }`}
+                style={{
+                  width: bubbleSize,
+                  height: bubbleSize,
+                  flexShrink: 0,
+                  boxSizing: "border-box",
+                  borderRadius: "50%",
+                  background: count === 0 ? hexA(color, isDark ? 0.3 : 0.32) : color,
+                  boxShadow: count >= 2 ? `0 4px 14px ${hexA(color, 0.5)}` : "none",
+                  border: isToday ? `${ringWidth}px solid ${ACCENT}` : "none",
+                  padding: 0,
+                }}
+              >
+                {count > 0 && (
+                  <span
+                    className="font-display font-extrabold"
+                    style={{ fontSize: numberSize, color: "#1B263B", lineHeight: 1 }}
+                  >
+                    {date.getDate()}
+                  </span>
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ConstellationMonth;

--- a/src/components/calendar/DayDetailPanel.tsx
+++ b/src/components/calendar/DayDetailPanel.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { Database } from "@/integrations/supabase/types";
+import DayEventCard from "@/components/calendar/DayEventCard";
+import { weekdayColor } from "@/components/calendar/weekdayColors";
+import { daysOfWeek, formatFrDayMonth } from "@/lib/utils";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+interface DayDetailPanelProps {
+  date: Date;
+  events: EventRow[];
+  size?: "mobile" | "desktop";
+  onChanged?: () => void;
+}
+
+/**
+ * Panneau « jour » : en-tête (puce date colorée + libellé + compteur) suivi de
+ * la liste des événements du jour. Utilisé dans le volet droit du desktop et
+ * dans le bottom sheet mobile.
+ */
+const DayDetailPanel = ({ date, events, size = "desktop", onChanged }: DayDetailPanelProps) => {
+  const color = weekdayColor(date);
+  const dayName = daysOfWeek[date.getDay()];
+  const title = formatFrDayMonth(date);
+  const count = events.length;
+  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* En-tête jour */}
+      <div className="flex items-center gap-3 px-1">
+        <div
+          className="flex h-14 w-14 flex-shrink-0 flex-col items-center justify-center rounded-2xl text-[#1B263B]"
+          style={{ background: color }}
+        >
+          <span className="font-display text-2xl font-extrabold leading-none">{date.getDate()}</span>
+          <span className="text-[9px] font-bold uppercase tracking-wide opacity-80">
+            {dayName.slice(0, 3)}.
+          </span>
+        </div>
+        <div>
+          <div className="font-display text-lg font-bold">{capitalize(title)}</div>
+          <div className="text-sm text-muted-foreground">
+            {count > 0
+              ? `${count} événement${count > 1 ? "s" : ""} ce jour-là`
+              : "Aucun événement ce jour-là"}
+          </div>
+        </div>
+      </div>
+
+      {/* Liste des événements */}
+      <div className="mt-4 flex flex-col gap-2.5 overflow-y-auto pb-2">
+        {events.map((event) => (
+          <DayEventCard key={event.id} event={event} size={size} onChanged={onChanged} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DayDetailPanel;

--- a/src/components/calendar/DayEventCard.tsx
+++ b/src/components/calendar/DayEventCard.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Clock, Euro, Image as ImageIcon, MapPin, Pencil, Ticket } from "lucide-react";
+import type { Database } from "@/integrations/supabase/types";
+import EventForm from "@/components/EventForm";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTheme } from "@/components/ThemeProvider";
+import { useUserRoleContext } from "@/components/UserRoleProvider";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { triggerRevalidate } from "@/lib/revalidate";
+import {
+  eventSlug,
+  formatCityName,
+  formatPrice,
+  formatTimeDisplay,
+  getEventStart,
+} from "@/lib/utils";
+import { hexA, weekdayColor } from "@/lib/colors";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+interface DayEventCardProps {
+  event: EventRow;
+  size?: "mobile" | "desktop";
+  /** Remonte une modification/suppression au parent pour rafraîchir le mois. */
+  onChanged?: () => void;
+}
+
+/**
+ * Carte d'événement riche du panneau jour de la vue calendrier : colonne média
+ * (affiche ou panneau coloré avec l'heure) + corps (titre, badges, lieu, prix,
+ * type, billetterie). Les superadmins disposent d'un bouton « Modifier » qui
+ * ouvre `EventForm`, exactement comme `EventCard`.
+ */
+const DayEventCard = ({ event: eventProp, size = "desktop", onChanged }: DayEventCardProps) => {
+  const big = size === "desktop";
+  const { theme } = useTheme();
+  const { toast } = useToast();
+  const { isSuperAdmin } = useUserRoleContext();
+  const [event, setEvent] = useState(eventProp);
+  const [showEdit, setShowEdit] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
+
+  useEffect(() => {
+    setEvent(eventProp);
+  }, [eventProp]);
+
+  const start = getEventStart(event);
+  const color = weekdayColor(start ?? new Date());
+  const timeLabel = formatTimeDisplay(event);
+  const locationString = `${event.location_place || ""}${
+    event.location_city ? ` — ${formatCityName(event.location_city)}` : ""
+  }${event.location_department ? ` (${event.location_department})` : ""}`;
+
+  const handleSaveEvent = async (data: Partial<EventRow>): Promise<boolean> => {
+    const cleanData = { ...data } as Record<string, unknown>;
+    delete cleanData.theme;
+    delete cleanData.recurrence;
+    delete cleanData.id;
+    if (cleanData.organization_id === "") cleanData.organization_id = null;
+    if (cleanData.theme_id === "") cleanData.theme_id = null;
+
+    const updated = { ...cleanData, updated_at: new Date().toISOString() };
+    const { error } = await supabase.from("events").update(updated).eq("id", event.id);
+    if (error) {
+      toast({ title: "Erreur lors de la mise à jour", description: error.message, variant: "destructive" });
+      return false;
+    }
+
+    setEvent((prev) => ({ ...prev, ...updated }) as EventRow);
+    void triggerRevalidate({
+      slug: eventSlug({ id: event.id, name: (updated as Partial<EventRow>).name ?? event.name }),
+      department: (updated as Partial<EventRow>).location_department ?? event.location_department,
+    });
+    toast({ title: "Événement mis à jour", description: "L'événement a été mis à jour avec succès" });
+    setShowEdit(false);
+    onChanged?.();
+    return true;
+  };
+
+  const handleDeleteEvent = async (): Promise<void> => {
+    const { error } = await supabase.from("events").delete().eq("id", event.id);
+    if (error) {
+      toast({ title: "Erreur lors de la suppression", description: error.message, variant: "destructive" });
+      return;
+    }
+    void triggerRevalidate({
+      slug: eventSlug({ id: event.id, name: event.name }),
+      department: event.location_department,
+    });
+    toast({ title: "Événement supprimé", description: "L'événement a été supprimé avec succès" });
+    setShowEdit(false);
+    setIsDeleted(true);
+    onChanged?.();
+  };
+
+  if (isDeleted) return null;
+
+  const mediaWidth = big ? 116 : 84;
+
+  return (
+    <div
+      className="flex overflow-hidden rounded-2xl border-0 shadow-sm bg-white dark:bg-ephemeride-light text-[#1B263B] dark:text-[#faf3ec]"
+      style={{ opacity: event.is_cancelled ? 0.62 : 1 }}
+    >
+      {/* Colonne média */}
+      <div
+        className="relative flex flex-shrink-0 items-center justify-center"
+        style={{
+          width: mediaWidth,
+          background: color,
+          backgroundImage: "linear-gradient(155deg, rgba(255,255,255,.18), rgba(27,38,59,.22))",
+        }}
+      >
+        {event.cover_url ? (
+          <>
+            <img
+              src={event.cover_url}
+              alt="Affiche de l'événement"
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+            {timeLabel && (
+              <span
+                className="absolute left-2 top-2 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-bold text-[#1B263B] shadow"
+                style={{ background: color, fontSize: big ? 12 : 11 }}
+              >
+                <Clock style={{ width: big ? 13 : 12, height: big ? 13 : 12 }} />
+                {timeLabel}
+              </span>
+            )}
+          </>
+        ) : timeLabel ? (
+          <span className="flex flex-col items-center gap-1 text-[#1B263B]">
+            <Clock style={{ width: big ? 18 : 16, height: big ? 18 : 16 }} />
+            <span
+              className="font-display font-extrabold"
+              style={{ fontSize: big ? 15 : 13 }}
+            >
+              {timeLabel}
+            </span>
+          </span>
+        ) : (
+          <ImageIcon style={{ width: big ? 30 : 24, height: big ? 30 : 24, color: hexA("#1B263B", 0.5) }} />
+        )}
+      </div>
+
+      {/* Corps */}
+      <div className="relative min-w-0 flex-1" style={{ padding: big ? "13px 16px" : "11px 13px" }}>
+        {/* Bouton Modifier (superadmins) */}
+        {isSuperAdmin && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setShowEdit(true)}
+                  aria-label="Modifier l'événement"
+                  className={`absolute right-2 top-2 z-10 rounded-full border p-1.5 transition-colors ${
+                    theme === "dark"
+                      ? "border-white/20 text-white/70 hover:bg-white/10 hover:text-white"
+                      : "border-gray-300 text-gray-600 hover:bg-gray-50 hover:text-gray-800"
+                  }`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left" className="text-xs">
+                Modifier l'événement
+              </TooltipContent>
+            </Tooltip>
+            <Dialog open={showEdit} onOpenChange={setShowEdit}>
+              <DialogContent
+                className={`mx-auto w-3/4 max-w-4xl max-h-[90vh] overflow-y-auto ${
+                  theme === "light"
+                    ? "bg-[#f8f8f6] text-ephemeride border-none"
+                    : "bg-ephemeride-light text-ephemeride-foreground border-none"
+                }`}
+              >
+                <DialogHeader>
+                  <DialogTitle>Modifier l'événement</DialogTitle>
+                </DialogHeader>
+                <EventForm
+                  event={event}
+                  onSave={handleSaveEvent}
+                  onCancel={() => setShowEdit(false)}
+                  onDelete={handleDeleteEvent}
+                />
+              </DialogContent>
+            </Dialog>
+          </>
+        )}
+
+        {/* Titre + badges */}
+        <div className={`flex flex-wrap items-center gap-2 ${isSuperAdmin ? "pr-8" : ""}`} style={{ marginBottom: big ? 7 : 5 }}>
+          <span className="font-bold leading-tight" style={{ fontSize: big ? 16 : 14 }}>
+            {event.name}
+          </span>
+          {event.is_full && (
+            <span className="inline-flex items-center rounded-full bg-red-600 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+              Complet
+            </span>
+          )}
+          {event.is_cancelled && (
+            <span className="inline-flex items-center rounded-full bg-gray-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white dark:bg-gray-200 dark:text-gray-900">
+              Annulé
+            </span>
+          )}
+        </div>
+
+        {/* Lieu */}
+        <div className="mt-0.5 flex items-center gap-1.5 text-muted-foreground">
+          <MapPin className="shrink-0" style={{ width: big ? 14 : 13, height: big ? 14 : 13 }} />
+          <span className="truncate" style={{ fontSize: big ? 13 : 12 }}>
+            {locationString}
+          </span>
+        </div>
+
+        {/* Prix */}
+        {event.price && (
+          <div className="mt-0.5 flex items-center gap-1.5 text-muted-foreground">
+            <Euro className="shrink-0" style={{ width: big ? 14 : 13, height: big ? 14 : 13 }} />
+            <span className="truncate" style={{ fontSize: big ? 13 : 12 }}>
+              {formatPrice(event.price)}
+            </span>
+          </div>
+        )}
+
+        {/* Pied : type + billetterie */}
+        <div className="flex items-center justify-between gap-2" style={{ marginTop: big ? 10 : 8 }}>
+          {event.audience ? (
+            <span className="inline-block rounded-full bg-[#1B263B]/5 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground dark:bg-white/10">
+              {event.audience}
+            </span>
+          ) : (
+            <span />
+          )}
+          {event.ticketing_url &&
+            (big ? (
+              <a
+                href={event.ticketing_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition-colors border-gray-300 text-[#1B263B] hover:bg-gray-50 dark:border-white/20 dark:text-[#faf3ec] dark:hover:bg-white/10"
+              >
+                <Ticket className="h-4 w-4" />
+                Billetterie
+              </a>
+            ) : (
+              <a
+                href={event.ticketing_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Accéder à la billetterie"
+                className="text-muted-foreground transition-transform hover:scale-110"
+              >
+                <Ticket className="h-5 w-5" />
+              </a>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DayEventCard;

--- a/src/components/calendar/EventCalendar.tsx
+++ b/src/components/calendar/EventCalendar.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { Database } from "@/integrations/supabase/types";
+import { Button } from "@/components/ui/button";
+import {
+  cn,
+  daysOfWeek,
+  formatFrTime,
+  getDateBlockColor,
+  getEventStart,
+  monthNames,
+  toISODate,
+} from "@/lib/utils";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+interface EventCalendarProps {
+  month: Date;
+  events: EventRow[];
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  onToday: () => void;
+  onSelectEvent: (event: EventRow) => void;
+}
+
+const WEEKDAY_LABELS = ["lun", "mar", "mer", "jeu", "ven", "sam", "dim"];
+const MAX_EVENTS_PER_DAY = 3;
+
+/**
+ * Vue calendrier mensuelle présentationnelle (aucun fetch). Affiche les
+ * événements fournis sur une grille lundi→dimanche ; un clic sur un événement
+ * déclenche `onSelectEvent`.
+ */
+export function EventCalendar({
+  month,
+  events,
+  onPrevMonth,
+  onNextMonth,
+  onToday,
+  onSelectEvent,
+}: EventCalendarProps) {
+  // Grille complète : semaines entières débordant sur les mois adjacents.
+  const days = eachDayOfInterval({
+    start: startOfWeek(startOfMonth(month), { weekStartsOn: 1 }),
+    end: endOfWeek(endOfMonth(month), { weekStartsOn: 1 }),
+  });
+
+  // Indexer les événements par jour (clé YYYY-MM-DD), triés par heure de début.
+  const eventsByDay = new Map<string, EventRow[]>();
+  for (const event of events) {
+    const start = getEventStart(event);
+    if (!start) continue;
+    const key = toISODate(start);
+    const list = eventsByDay.get(key);
+    if (list) list.push(event);
+    else eventsByDay.set(key, [event]);
+  }
+  for (const list of eventsByDay.values()) {
+    list.sort((a, b) => {
+      const sa = getEventStart(a)?.getTime() ?? 0;
+      const sb = getEventStart(b)?.getTime() ?? 0;
+      return sa - sb;
+    });
+  }
+
+  const today = new Date();
+
+  return (
+    <div className="rounded-md border bg-card">
+      {/* En-tête : navigation + libellé du mois */}
+      <div className="flex items-center justify-between gap-2 border-b p-3">
+        <h2 className="text-lg font-semibold capitalize">
+          {monthNames[month.getMonth()]} {month.getFullYear()}
+        </h2>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={onToday}>
+            Aujourd'hui
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onPrevMonth}
+            aria-label="Mois précédent"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onNextMonth}
+            aria-label="Mois suivant"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* En-têtes de colonnes */}
+      <div className="grid grid-cols-7 border-b">
+        {WEEKDAY_LABELS.map((label) => (
+          <div
+            key={label}
+            className="p-2 text-center text-xs font-medium uppercase text-muted-foreground"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Grille des jours */}
+      <div className="grid grid-cols-7">
+        {days.map((day) => {
+          const inMonth = isSameMonth(day, month);
+          const isToday = isSameDay(day, today);
+          const dayEvents = eventsByDay.get(toISODate(day)) ?? [];
+          const visible = dayEvents.slice(0, MAX_EVENTS_PER_DAY);
+          const overflow = dayEvents.length - visible.length;
+          const blockColor = getDateBlockColor(daysOfWeek[day.getDay()]);
+
+          return (
+            <div
+              key={day.toISOString()}
+              className={cn(
+                "flex min-h-[7rem] flex-col gap-1 border-b border-r p-1.5",
+                !inMonth && "bg-muted/30",
+              )}
+            >
+              <div className="flex justify-end">
+                <span
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full text-xs",
+                    !inMonth && "text-muted-foreground/60",
+                    isToday && "bg-primary font-semibold text-primary-foreground",
+                  )}
+                >
+                  {day.getDate()}
+                </span>
+              </div>
+
+              <div className="flex flex-col gap-1 overflow-y-auto">
+                {visible.map((event) => {
+                  const start = getEventStart(event);
+                  return (
+                    <button
+                      key={event.id}
+                      type="button"
+                      onClick={() => onSelectEvent(event)}
+                      title={event.name}
+                      className={cn(
+                        "flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-xs text-white transition-opacity hover:opacity-80",
+                        blockColor,
+                        event.is_cancelled && "opacity-60 line-through",
+                      )}
+                    >
+                      {event.emoji && (
+                        <span className="shrink-0">{event.emoji}</span>
+                      )}
+                      {start && (
+                        <span className="shrink-0 font-medium tabular-nums">
+                          {formatFrTime(start)}
+                        </span>
+                      )}
+                      <span className="truncate">{event.name}</span>
+                      {event.is_full && (
+                        <span className="ml-auto shrink-0 rounded bg-black/25 px-1 text-[10px] uppercase">
+                          Complet
+                        </span>
+                      )}
+                      {event.is_cancelled && (
+                        <span className="ml-auto shrink-0 rounded bg-black/25 px-1 text-[10px] uppercase">
+                          Annulé
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+                {overflow > 0 && (
+                  <span className="px-1 text-[11px] text-muted-foreground">
+                    +{overflow} autre{overflow > 1 ? "s" : ""}
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default EventCalendar;

--- a/src/components/calendar/weekdayColors.ts
+++ b/src/components/calendar/weekdayColors.ts
@@ -1,0 +1,40 @@
+/**
+ * Constantes propres à la grille calendrier « Constellation ».
+ * La palette de couleurs par jour et l'accent vivent dans `src/lib/colors.ts`
+ * (source unique) et sont ré-exportés ici pour la commodité des composants
+ * calendrier.
+ */
+export { ACCENT, WEEKDAY_HEX, weekdayColor } from "@/lib/colors";
+
+/**
+ * Ordre des colonnes du calendrier : semaine commençant le lundi.
+ * Valeurs = `Date.getDay()`.
+ */
+export const WEEK_ORDER = [1, 2, 3, 4, 5, 6, 0] as const;
+
+/** Lettre courte par jour (en-têtes mobile). */
+export const WEEKDAY_LETTER: Record<number, string> = {
+  1: "L",
+  2: "M",
+  3: "M",
+  4: "J",
+  5: "V",
+  6: "S",
+  0: "D",
+};
+
+/** Libellé court 3 lettres par jour (en-têtes desktop). */
+export const WEEKDAY_SHORT: Record<number, string> = {
+  1: "lun",
+  2: "mar",
+  3: "mer",
+  4: "jeu",
+  5: "ven",
+  6: "sam",
+  0: "dim",
+};
+
+/** Convertit un `getDay()` (lundi=1) en offset de colonne (lundi=0). */
+export function mondayOffset(getDay: number): number {
+  return (getDay + 6) % 7;
+}

--- a/src/hooks/use-drag-to-close.ts
+++ b/src/hooks/use-drag-to-close.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRef, useState, type TouchEvent } from "react";
+
+/**
+ * Gestion du glissé vertical d'un tiroir (bottom sheet) : la zone de préhension
+ * suit le doigt vers le bas et ferme au-delà d'un seuil, comme un vrai tiroir.
+ *
+ * Renvoie le décalage courant `dragY` (à appliquer en `translateY`) et les
+ * handlers tactiles à poser sur la zone à glisser.
+ */
+export function useDragToClose(onClose: () => void, threshold = 80) {
+  const [dragY, setDragY] = useState(0);
+  const startY = useRef<number | null>(null);
+
+  const handlers = {
+    onTouchStart: (e: TouchEvent) => {
+      startY.current = e.touches[0].clientY;
+    },
+    onTouchMove: (e: TouchEvent) => {
+      if (startY.current == null) return;
+      const dy = e.touches[0].clientY - startY.current;
+      if (dy > 0) setDragY(dy);
+    },
+    onTouchEnd: () => {
+      if (dragY > threshold) onClose();
+      setDragY(0);
+      startY.current = null;
+    },
+  };
+
+  return { dragY, handlers };
+}

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,35 @@
+/**
+ * Couleurs partagées de l'app.
+ *
+ * `WEEKDAY_HEX` est la source unique de la palette « une teinte par jour de la
+ * semaine » (index = `Date.getDay()`, 0 = dimanche … 6 = samedi), utilisée en
+ * style inline (bulles du calendrier, dégradés). La même palette existe sous
+ * forme de classes Tailwind dans `getDateBlockColor` (src/lib/utils.ts) : ces
+ * classes DOIVENT rester des littéraux statiques pour être extraites par
+ * Tailwind, on ne peut donc pas les dériver dynamiquement d'ici — garder les
+ * deux en phase si la palette change.
+ */
+export const WEEKDAY_HEX: Record<number, string> = {
+  0: "#D4A5A5", // dimanche — rose terreux
+  1: "#8B9DC3", // lundi — bleu ardoise doux
+  2: "#D4A574", // mardi — jaune ocre pastel
+  3: "#9CAF88", // mercredi — vert sauge
+  4: "#A8B5C8", // jeudi — bleu gris doux
+  5: "#C89B7B", // vendredi — brique doux
+  6: "#B8A9D9", // samedi — lavande désaturée
+};
+
+/** Couleur de la bulle pour une date ou un index de jour. */
+export function weekdayColor(day: Date | number): string {
+  const index = typeof day === "number" ? day : day.getDay();
+  return WEEKDAY_HEX[index] ?? "#9aa0ab";
+}
+
+/** Couleur d'accent de marque (pêche), ex. anneau « aujourd'hui ». */
+export const ACCENT = "#ED9873";
+
+/** Convertit un hex (#rrggbb) en chaîne rgba avec alpha. */
+export function hexA(hex: string, alpha: number): string {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+}

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -1,4 +1,4 @@
-import { daysOfWeek, formatFrTime, getEventEnd, getEventStart } from "@/lib/utils";
+import { daysOfWeek, formatFrTime, getEventEnd, getEventStart, toISODate } from "@/lib/utils";
 
 /**
  * Règle de récurrence hebdomadaire.
@@ -43,14 +43,6 @@ export type RecurringSharedFields = {
 function parseISODate(iso: string): Date {
   const [year, month, day] = iso.split("-").map((part) => parseInt(part, 10));
   return new Date(year, month - 1, day, 12, 0, 0, 0);
-}
-
-/** Formate une `Date` locale en `YYYY-MM-DD`. */
-function toISODate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,6 +101,10 @@ export function getDayOfWeek(dateISO: string): string {
   return daysOfWeek[d.getDay()];
 }
 
+// NB : la même palette existe en hex dans `WEEKDAY_HEX` (src/lib/colors.ts),
+// utilisée en style inline par le calendrier. Garder les deux en phase — on ne
+// peut pas dériver ces classes dynamiquement car Tailwind n'extrait que des
+// littéraux statiques.
 export function getDateBlockColor(day: string): string {
   switch (day) {
     case "lundi":
@@ -157,6 +161,14 @@ export function parseLocalDateTime(value?: string | null): Date | null {
   );
 }
 
+/** Formate une `Date` locale en `YYYY-MM-DD`. */
+export function toISODate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 /** Date+heure de début d'un événement (null si `start_at` absent). */
 export function getEventStart(event: EventTimeFields): Date | null {
   return parseLocalDateTime(event.start_at);
@@ -177,6 +189,11 @@ export function formatFrTime(date: Date): string {
 /** Libellé de date long en français : "mercredi 21 mai 2025". */
 export function formatFrDateLabel(date: Date): string {
   return `${daysOfWeek[date.getDay()]} ${date.getDate()} ${monthNames[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+/** Libellé jour + mois en français, sans l'année : "mercredi 21 mai". */
+export function formatFrDayMonth(date: Date): string {
+  return `${daysOfWeek[date.getDay()]} ${date.getDate()} ${monthNames[date.getMonth()]}`;
 }
 
 /**

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
+        display: ['var(--font-display)', 'Inter', 'system-ui', 'sans-serif'],
       },
       colors: {
         ephemeride: "#1B263B", // Bleu nuit plus doux


### PR DESCRIPTION
## Contexte

La home publique n'affichait les événements que sous forme de **liste**. Cette PR ajoute une **vue calendrier mensuelle publique** (accessible à tous) via une bascule **Liste / Calendrier**.

> La PR contient la page admin `/admin/calendar` (réservée superadmin, faite séparément) et — l'essentiel — la **vue calendrier publique nommée « Constellation »**.

## Ce que ça fait

- **Vue « Constellation »** : grille mensuelle où chaque jour est une bulle colorée selon le jour de la semaine et **dimensionnée selon le nombre d'événements**. Tailles proportionnelles à la largeur de colonne (responsive tablette → desktop, sans chevauchement).
- **Desktop** : deux volets 50/50 (calendrier + détail du jour). **Mobile** : tiroir des événements qui glisse depuis le menu du bas (glissé tactile pour fermer).
- **Panneau jour** : affiche, badges Complet/Annulé, lieu, prix, type, billetterie ; bouton **« Modifier » réservé aux superadmins** (réutilise `EventForm`).
- **Refonte navigation mobile** : menu fixe en bas (Liste / **+** / Agenda, thème, filtres), tiroir de filtres glissable avec badge quand un filtre est actif ; switch de vue déplacé dans le header sticky.
- **Filtres partagés** entre les deux vues (desktop : barre commune ; mobile : tiroir).
- Compteur + dernière mise à jour déplacés dans le **footer** ; barre de partage masquée (conservée dans le code) ; titre « Événements à venir » retiré.
- Police d'affichage **Bricolage Grotesque** ; `ThemeToggle` en bouton rond.
- **Port de dev → 8080** (sans impact sur le déploiement Vercel).

## Qualité / refactor

- Helpers couleurs centralisés (`src/lib/colors.ts` : `hexA`, palette `WEEKDAY_HEX`, `weekdayColor`).
- Hook partagé `useDragToClose` pour les deux bottom-sheets (filtres + événements).
- Réutilisation des helpers de date (`formatFrDateLabel`, `formatFrTime`, `formatFrDayMonth`).

## Vérification

- `pnpm build` ✅ — `pnpm lint` ✅ (0 erreur).
- À tester manuellement : bascule Liste/Calendrier, navigation mois, sélection d'un jour (desktop volet / mobile tiroir), thème clair/sombre, filtres, et le bouton Modifier en superadmin.