### PR TITLE
feat(inbound-email): redirection des e-mails entrants Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,15 @@ NEXT_PUBLIC_VAPID_PUBLIC_KEY=votre-cle-vapid-publique
 # La clé VAPID privée + le sujet sont des secrets de l'Edge Function, PAS ici :
 #   supabase secrets set VAPID_PUBLIC_KEY=... VAPID_PRIVATE_KEY=... VAPID_SUBJECT=mailto:leny@communo.app
 
-# Fallback e-mail (Resend) — secrets de l'Edge Function (à mettre dans .env.local
-# puis `make supabase-secrets-email`). Domaine expéditeur à vérifier dans Resend.
+# E-mail (Resend) — secrets de l'Edge Function (à mettre dans .env.local puis
+# `make supabase-secrets-email`). Domaine expéditeur à vérifier dans Resend.
 #   RESEND_API_KEY=re_xxx
 #   RESEND_FROM=Éphéméride <no-reply@ephemeride.app>
+# Redirection des mails entrants (webhook Resend email.received → ces adresses,
+# séparées par des virgules). Vide = aucune redirection.
+#   RESEND_EMAIL_RECEIVED_FORWARD=leny.bernard@gmail.com
+# Signing secret du webhook Resend (Resend → Webhooks → endpoint email.received).
+#   RESEND_WEBHOOK_SECRET=whsec_xxx
 
 # --- Secrets serveur (à mettre dans .env.local, NON versionné) ---
 # Secret partagé pour la revalidation ISR à la demande (/api/revalidate)

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,15 @@ supabase-secrets:
 		VAPID_PRIVATE_KEY="$(VAPID_PRIVATE_KEY)" \
 		VAPID_SUBJECT="$(VAPID_SUBJECT)"
 
-# Configure les secrets Resend pour le fallback e-mail (valeurs depuis .env.local).
+# Configure les secrets Resend (e-mails sortants + redirection des mails entrants).
 # RESEND_FROM doit utiliser un domaine expéditeur vérifié dans Resend.
 supabase-secrets-email:
 	npx supabase secrets set \
 		RESEND_API_KEY="$(RESEND_API_KEY)" \
 		RESEND_FROM="$(RESEND_FROM)" \
-		SITE_URL="$(NEXT_PUBLIC_SITE_URL)"
+		SITE_URL="$(NEXT_PUBLIC_SITE_URL)" \
+		RESEND_EMAIL_RECEIVED_FORWARD="$(RESEND_EMAIL_RECEIVED_FORWARD)" \
+		RESEND_WEBHOOK_SECRET="$(RESEND_WEBHOOK_SECRET)"
 
 # Déploiement complet de la fonctionnalité notifications push :
 # migration + secrets + déploiement de toutes les fonctions.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,53 @@ Copier `.env.example` et renseigner les valeurs. Voir ce fichier pour la liste c
 - `NEXT_PUBLIC_SITE_URL` — URL publique du site (canonical, OpenGraph, sitemap).
 - `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST` — analytics (optionnel).
 - `REVALIDATE_SECRET` — secret partagé pour `/api/revalidate` (usage serveur/webhook).
+- `RESEND_API_KEY`, `RESEND_FROM` — envoi d'e-mails via Resend (Edge Functions).
+- `RESEND_EMAIL_RECEIVED_FORWARD` — adresse(s) de redirection des e-mails entrants (séparées par des virgules). Voir [Redirection des e-mails entrants](#redirection-des-e-mails-entrants-resend).
+- `RESEND_WEBHOOK_SECRET` — secret de signature du webhook Resend `email.received`.
 
-Les secrets serveur (`SUPABASE_DB_URL`, `REVALIDATE_SECRET`) vont dans `.env.local` (non versionné).
+Les secrets serveur (`SUPABASE_DB_URL`, `REVALIDATE_SECRET`) et les secrets Resend vont dans `.env.local` (non versionné).
 
 ## Types Supabase
 
 ```sh
 make supabase-types   # régénère src/lib/database.types.ts
 ```
+
+## Redirection des e-mails entrants (Resend)
+
+Le domaine peut **recevoir** des e-mails via la fonctionnalité _Inbound_ de Resend. L'Edge Function Supabase [`forward-inbound-email`](supabase/functions/forward-inbound-email/index.ts) écoute l'événement webhook `email.received` et **redirige** chaque message reçu vers la ou les adresses définies dans `RESEND_EMAIL_RECEIVED_FORWARD`.
+
+Le webhook Resend ne transmet que des **métadonnées**. La fonction récupère donc le corps du mail (`GET /emails/receiving/{id}`) puis ses pièces jointes (`GET /emails/receiving/{id}/attachments`), avant de **ré-émettre** un nouveau message depuis le domaine vérifié (`RESEND_FROM`). Le `reply-to` pointe vers l'expéditeur d'origine, et un bandeau « Redirigé via Éphéméride » est ajouté. Les pièces jointes dépassant ~25 Mo cumulés sont omises et signalées dans le bandeau.
+
+La fonction reste **inerte** tant que `RESEND_EMAIL_RECEIVED_FORWARD` est vide.
+
+### Configuration
+
+1. Renseigner dans `.env.local` (non versionné) :
+
+   ```sh
+   RESEND_API_KEY=re_xxx
+   RESEND_FROM=Éphéméride <bonjour@ephemeride.link>   # domaine vérifié dans Resend
+   RESEND_EMAIL_RECEIVED_FORWARD=leny.bernard@gmail.com   # plusieurs adresses possibles, séparées par des virgules
+   RESEND_WEBHOOK_SECRET=                              # rempli à l'étape 3
+   ```
+
+2. Déployer la fonction et noter son URL :
+
+   ```sh
+   make deploy-fn FN=forward-inbound-email
+   # → https://<project-ref>.supabase.co/functions/v1/forward-inbound-email
+   ```
+
+3. Côté **Resend** → _Webhooks_ → _Add Endpoint_ :
+   - **URL** : l'URL de la fonction (étape 2) ;
+   - **Événement** : `email.received` ;
+   - copier le **Signing Secret** affiché (format `whsec_…`) dans `RESEND_WEBHOOK_SECRET` (`.env.local`).
+
+4. Pousser les secrets vers l'Edge Function :
+
+   ```sh
+   make supabase-secrets-email
+   ```
+
+Logs en cas de souci : `npx supabase functions logs forward-inbound-email`.

--- a/docs/superpowers/plans/2026-06-26-forward-inbound-email.md
+++ b/docs/superpowers/plans/2026-06-26-forward-inbound-email.md
@@ -1,0 +1,619 @@
+# Redirection des mails entrants Resend — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rediriger automatiquement les mails reçus sur le domaine Resend vers une ou plusieurs adresses configurées, via une Edge Function Supabase déclenchée par le webhook `email.received`.
+
+**Architecture:** Une Edge Function Deno `forward-inbound-email` reçoit le webhook `email.received` (qui ne contient que des métadonnées), vérifie sa signature Svix, récupère le corps via l'API Receiving de Resend (`GET /emails/receiving/{id}`) et les pièces jointes via l'API Attachments (`GET /emails/receiving/{id}/attachments`, qui renvoie des `download_url` signés), puis recompose et ré-émet un nouveau mail via `POST /emails` depuis le domaine vérifié. La logique de recomposition (pure, sans réseau) vit dans `forward.ts` et est testée unitairement ; `index.ts` orchestre les appels réseau.
+
+**Tech Stack:** Supabase Edge Functions (runtime Deno), API REST Resend, `npm:standardwebhooks@1.0.0` (vérif signature), `jsr:@std/encoding@1/base64` (encodage PJ), `jsr:@std/assert@1` (tests).
+
+## Global Constraints
+
+- Runtime Deno (Edge Function Supabase) — imports via `npm:` et `jsr:`, accès env via `Deno.env.get(...)`. Une seule des variables présentes/absentes peut changer le comportement ; ne jamais faire échouer durement sur une config manquante autre que `RESEND_API_KEY`.
+- Domaine expéditeur : `RESEND_FROM` (défaut `Éphéméride <bonjour@ephemeride.link>`), doit être un domaine vérifié dans Resend.
+- Textes destinés à l'utilisateur en français, avec accents corrects.
+- Le webhook Resend n'envoie pas de JWT Supabase → la fonction doit être déployée avec `verify_jwt = false`.
+- Limite Resend ~40 Mo par mail ; le base64 gonfle d'environ 33 %. Budget pièces jointes fixé à 25 Mo de données brutes (`MAX_ATTACHMENTS_BYTES`).
+- Format du payload webhook `email.received` :
+  ```json
+  { "type": "email.received", "created_at": "...", "data": { "email_id": "uuid", "from": "...", "to": ["..."], "subject": "...", "attachments": [ ... ] } }
+  ```
+- Headers de signature envoyés par Resend : `svix-id`, `svix-timestamp`, `svix-signature`.
+- Réponse de `GET /emails/receiving/{id}` : champs `id`, `from`, `to`, `cc`, `bcc`, `subject`, `html`, `text`, `reply_to`, `headers`, `attachments`, `raw`. Paramètre `?html_format=data_uri` pour embarquer les images inline.
+- Réponse de `GET /emails/receiving/{id}/attachments` : `{ "data": [ { id, filename, size, content_type, content_disposition, content_id, download_url, expires_at } ] }`.
+
+---
+
+## File Structure
+
+- `supabase/functions/forward-inbound-email/forward.ts` — **créé** : logique pure de recomposition (parsing adresses, extraction nom/adresse, sélection PJ, construction de l'email de sortie). Aucune dépendance réseau.
+- `supabase/functions/forward-inbound-email/forward.test.ts` — **créé** : tests unitaires Deno de `forward.ts`.
+- `supabase/functions/forward-inbound-email/index.ts` — **créé** : orchestrateur HTTP (vérif signature, récupération corps + PJ, envoi). Thin, non testé automatiquement (réseau) ; testé manuellement.
+- `supabase/config.toml` — **modifié** : ajout de `[functions.forward-inbound-email]` avec `verify_jwt = false`.
+- `.env.example` — **modifié** : documentation des nouveaux secrets `RESEND_EMAIL_RECEIVED_FORWARD` et `RESEND_WEBHOOK_SECRET`.
+- `Makefile` — **modifié** : la cible `supabase-secrets-email` pousse aussi les deux nouveaux secrets.
+
+---
+
+## Task 1: Module pur de recomposition (`forward.ts`) + tests unitaires
+
+**Files:**
+- Create: `supabase/functions/forward-inbound-email/forward.ts`
+- Test: `supabase/functions/forward-inbound-email/forward.test.ts`
+
+**Interfaces:**
+- Consumes: rien (premier task).
+- Produces (utilisés par Task 2) :
+  - `parseForwardAddresses(raw: string | undefined): string[]`
+  - `bareAddress(addr: string): string`
+  - `senderName(from: string): string`
+  - `buildFrom(resendFrom: string, originalFrom: string): string`
+  - `selectAttachments(metas: InboundAttachmentMeta[], maxTotalBytes: number): { keep: InboundAttachmentMeta[]; skipped: string[] }`
+  - `buildForwardEmail(params: { received: ReceivedEmail; forwardTo: string[]; resendFrom: string; attachments: OutboundAttachment[]; skippedAttachments: string[] }): ForwardEmail`
+  - types exportés : `InboundAttachmentMeta`, `ReceivedEmail`, `OutboundAttachment`, `ForwardEmail`
+
+- [ ] **Step 1: Écrire le fichier de tests qui échoue**
+
+Créer `supabase/functions/forward-inbound-email/forward.test.ts` :
+
+```ts
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  bareAddress,
+  buildForwardEmail,
+  buildFrom,
+  parseForwardAddresses,
+  selectAttachments,
+  senderName,
+} from "./forward.ts";
+
+Deno.test("parseForwardAddresses : sépare, trim, ignore les vides", () => {
+  assertEquals(parseForwardAddresses("a@x.com, b@y.com ,, c@z.com"), [
+    "a@x.com",
+    "b@y.com",
+    "c@z.com",
+  ]);
+  assertEquals(parseForwardAddresses(undefined), []);
+  assertEquals(parseForwardAddresses(""), []);
+});
+
+Deno.test("bareAddress : extrait l'adresse e-mail", () => {
+  assertEquals(bareAddress("Jean Dupont <jean@x.com>"), "jean@x.com");
+  assertEquals(bareAddress("jean@x.com"), "jean@x.com");
+});
+
+Deno.test("senderName : nom d'affichage, sinon adresse", () => {
+  assertEquals(senderName("Jean Dupont <jean@x.com>"), "Jean Dupont");
+  assertEquals(senderName('"Jean Dupont" <jean@x.com>'), "Jean Dupont");
+  assertEquals(senderName("jean@x.com"), "jean@x.com");
+});
+
+Deno.test("buildFrom : nom d'origine + domaine vérifié", () => {
+  assertEquals(
+    buildFrom("Éphéméride <bonjour@ephemeride.link>", "Jean Dupont <jean@x.com>"),
+    "Jean Dupont (via Éphéméride) <bonjour@ephemeride.link>",
+  );
+});
+
+Deno.test("selectAttachments : ignore inline et hors budget", () => {
+  const metas = [
+    { id: "1", filename: "inline.png", content_type: "image/png", content_disposition: "inline", size: 10 },
+    { id: "2", filename: "doc.pdf", content_type: "application/pdf", content_disposition: "attachment", size: 100 },
+    { id: "3", filename: "big.zip", content_type: "application/zip", content_disposition: "attachment", size: 1000 },
+  ];
+  const { keep, skipped } = selectAttachments(metas, 500);
+  assertEquals(keep.map((a) => a.filename), ["doc.pdf"]);
+  assertEquals(skipped, ["big.zip"]);
+});
+
+Deno.test("buildForwardEmail : compose from/to/reply_to/subject + bandeau", () => {
+  const out = buildForwardEmail({
+    received: {
+      id: "e1",
+      from: "Jean Dupont <jean@x.com>",
+      to: ["contact@ephemeride.link"],
+      subject: "Bonjour",
+      html: "<p>Salut</p>",
+      text: "Salut",
+    },
+    forwardTo: ["leny.bernard@gmail.com"],
+    resendFrom: "Éphéméride <bonjour@ephemeride.link>",
+    attachments: [{ filename: "doc.pdf", content: "QUJD", content_type: "application/pdf" }],
+    skippedAttachments: [],
+  });
+  assertEquals(out.from, "Jean Dupont (via Éphéméride) <bonjour@ephemeride.link>");
+  assertEquals(out.to, ["leny.bernard@gmail.com"]);
+  assertEquals(out.reply_to, "jean@x.com");
+  assertEquals(out.subject, "Bonjour");
+  assertEquals(out.attachments?.length, 1);
+  assertEquals(out.html?.includes("Redirigé via Éphéméride"), true);
+  assertEquals(out.html?.includes("<p>Salut</p>"), true);
+  assertEquals(out.text?.includes("Salut"), true);
+});
+
+Deno.test("buildForwardEmail : corps minimal si ni html ni text", () => {
+  const out = buildForwardEmail({
+    received: { id: "e2", from: "jean@x.com", to: ["c@ephemeride.link"], subject: "Vide" },
+    forwardTo: ["leny.bernard@gmail.com"],
+    resendFrom: "Éphéméride <bonjour@ephemeride.link>",
+    attachments: [],
+    skippedAttachments: ["gros.zip"],
+  });
+  assertEquals(out.html, undefined);
+  assertEquals(out.text?.includes("(message sans contenu)"), true);
+  assertEquals(out.text?.includes("gros.zip"), true);
+  assertEquals(out.attachments, undefined);
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `deno test supabase/functions/forward-inbound-email/forward.test.ts`
+Expected: FAIL (module `./forward.ts` introuvable / exports manquants).
+
+- [ ] **Step 3: Écrire l'implémentation `forward.ts`**
+
+Créer `supabase/functions/forward-inbound-email/forward.ts` :
+
+```ts
+// Logique pure de recomposition d'un mail entrant Resend vers une redirection.
+// Aucune dépendance réseau ici → testable unitairement avec `deno test`.
+
+export interface InboundAttachmentMeta {
+  id: string;
+  filename: string;
+  content_type: string;
+  content_disposition: string; // "inline" | "attachment"
+  content_id?: string;
+  size?: number;
+  download_url?: string;
+}
+
+export interface ReceivedEmail {
+  id: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  reply_to?: string[];
+}
+
+export interface OutboundAttachment {
+  filename: string;
+  content: string; // base64
+  content_type?: string;
+}
+
+export interface ForwardEmail {
+  from: string;
+  to: string[];
+  reply_to: string;
+  subject: string;
+  html?: string;
+  text?: string;
+  attachments?: OutboundAttachment[];
+}
+
+// "a@x.com, b@y.com" -> ["a@x.com", "b@y.com"]
+export function parseForwardAddresses(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+// "Jean Dupont <jean@x.com>" -> "jean@x.com" ; "jean@x.com" -> "jean@x.com"
+export function bareAddress(addr: string): string {
+  const m = addr.match(/<([^>]+)>/);
+  return (m ? m[1] : addr).trim();
+}
+
+// "Jean Dupont <jean@x.com>" -> "Jean Dupont" ; "jean@x.com" -> "jean@x.com"
+export function senderName(from: string): string {
+  const m = from.match(/^\s*"?([^"<]*?)"?\s*<[^>]+>\s*$/);
+  const name = m && m[1] ? m[1].trim() : "";
+  return name || bareAddress(from);
+}
+
+// from d'envoi : nom de l'expéditeur d'origine, adresse de notre domaine vérifié.
+export function buildFrom(resendFrom: string, originalFrom: string): string {
+  return `${senderName(originalFrom)} (via Éphéméride) <${bareAddress(resendFrom)}>`;
+}
+
+// Garde les pièces jointes "réelles" (non inline) tant que le budget n'est pas
+// dépassé ; renvoie aussi les noms ignorés pour les signaler dans le bandeau.
+export function selectAttachments(
+  metas: InboundAttachmentMeta[],
+  maxTotalBytes: number,
+): { keep: InboundAttachmentMeta[]; skipped: string[] } {
+  const keep: InboundAttachmentMeta[] = [];
+  const skipped: string[] = [];
+  let total = 0;
+  for (const a of metas) {
+    if (a.content_disposition === "inline") continue; // déjà embarquée dans le HTML (data_uri)
+    const size = a.size ?? 0;
+    if (total + size > maxTotalBytes) {
+      skipped.push(a.filename);
+      continue;
+    }
+    total += size;
+    keep.push(a);
+  }
+  return { keep, skipped };
+}
+
+function bannerHtml(originalFrom: string, originalTo: string[], skipped: string[]): string {
+  const skippedLine = skipped.length
+    ? `<br/>Pièces jointes trop volumineuses, non incluses : ${skipped.join(", ")}.`
+    : "";
+  return `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#64748b;border-left:3px solid #ED9873;padding:8px 12px;margin:0 0 16px;background:#faf3ec;">
+  Redirigé via Éphéméride — de <strong>${originalFrom}</strong>, à l'origine vers ${originalTo.join(", ")}.${skippedLine}
+</div>`;
+}
+
+function bannerText(originalFrom: string, originalTo: string[], skipped: string[]): string {
+  const skippedLine = skipped.length
+    ? `\nPièces jointes trop volumineuses, non incluses : ${skipped.join(", ")}.`
+    : "";
+  return `Redirigé via Éphéméride — de ${originalFrom}, à l'origine vers ${originalTo.join(", ")}.${skippedLine}\n\n`;
+}
+
+export function buildForwardEmail(params: {
+  received: ReceivedEmail;
+  forwardTo: string[];
+  resendFrom: string;
+  attachments: OutboundAttachment[];
+  skippedAttachments: string[];
+}): ForwardEmail {
+  const { received, forwardTo, resendFrom, attachments, skippedAttachments } = params;
+  const to = received.to ?? [];
+  const out: ForwardEmail = {
+    from: buildFrom(resendFrom, received.from),
+    to: forwardTo,
+    reply_to: bareAddress(received.from),
+    subject: received.subject ?? "(sans objet)",
+  };
+  if (received.html != null) {
+    out.html = bannerHtml(received.from, to, skippedAttachments) + received.html;
+  }
+  if (received.text != null) {
+    out.text = bannerText(received.from, to, skippedAttachments) + received.text;
+  }
+  // Si ni html ni text, garantir un corps minimal.
+  if (out.html == null && out.text == null) {
+    out.text = bannerText(received.from, to, skippedAttachments) + "(message sans contenu)";
+  }
+  if (attachments.length > 0) out.attachments = attachments;
+  return out;
+}
+```
+
+- [ ] **Step 4: Lancer les tests pour vérifier qu'ils passent**
+
+Run: `deno test supabase/functions/forward-inbound-email/forward.test.ts`
+Expected: PASS (tous les tests verts).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/forward-inbound-email/forward.ts supabase/functions/forward-inbound-email/forward.test.ts
+git commit -m "feat(inbound-email): logique pure de recomposition + tests"
+```
+
+---
+
+## Task 2: Orchestrateur HTTP (`index.ts`) + config JWT
+
+**Files:**
+- Create: `supabase/functions/forward-inbound-email/index.ts`
+- Modify: `supabase/config.toml` (ajout du bloc `[functions.forward-inbound-email]`)
+
+**Interfaces:**
+- Consumes (de Task 1) : `parseForwardAddresses`, `selectAttachments`, `buildForwardEmail`, et les types `InboundAttachmentMeta`, `OutboundAttachment`, `ReceivedEmail`.
+- Produces : un endpoint HTTP `POST` (le webhook). Pas d'export consommé par d'autres tasks.
+
+- [ ] **Step 1: Écrire `index.ts`**
+
+Créer `supabase/functions/forward-inbound-email/index.ts` :
+
+```ts
+// Webhook Resend `email.received` : redirige les mails entrants vers la/les
+// adresse(s) de RESEND_EMAIL_RECEIVED_FORWARD.
+//
+// Resend ne livre que des métadonnées dans le webhook : on récupère le corps via
+// l'API Receiving puis les pièces jointes via l'API Attachments, et on ré-émet un
+// nouveau mail via l'API d'envoi depuis notre domaine vérifié.
+//
+// Configuration (Resend → Webhooks → ajouter un endpoint sur `email.received`) :
+//   - pointer vers cette fonction,
+//   - copier le "Signing Secret" dans le secret `RESEND_WEBHOOK_SECRET`.
+// Déploiement : `make deploy-fn FN=forward-inbound-email`
+//
+// Secrets : RESEND_API_KEY (requis), RESEND_FROM, RESEND_EMAIL_RECEIVED_FORWARD,
+//           RESEND_WEBHOOK_SECRET.
+
+import { Webhook } from "npm:standardwebhooks@1.0.0";
+import { encodeBase64 } from "jsr:@std/encoding@1/base64";
+import {
+  buildForwardEmail,
+  type InboundAttachmentMeta,
+  type OutboundAttachment,
+  parseForwardAddresses,
+  type ReceivedEmail,
+  selectAttachments,
+} from "./forward.ts";
+
+const DEFAULT_FROM = "Éphéméride <bonjour@ephemeride.link>";
+const MAX_ATTACHMENTS_BYTES = 25 * 1024 * 1024; // marge sous la limite ~40 Mo (base64 +33 %)
+
+interface InboundWebhook {
+  type: string;
+  data: { email_id: string };
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+
+  const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
+  if (!RESEND_API_KEY) {
+    return new Response(JSON.stringify({ error: "RESEND_API_KEY manquant" }), { status: 500 });
+  }
+  const RESEND_FROM = Deno.env.get("RESEND_FROM") ?? DEFAULT_FROM;
+  const forwardTo = parseForwardAddresses(Deno.env.get("RESEND_EMAIL_RECEIVED_FORWARD"));
+  const hookSecret = Deno.env.get("RESEND_WEBHOOK_SECRET");
+
+  const raw = await req.text();
+
+  // Vérifie la signature Svix émise par Resend (si le secret est configuré).
+  let payload: InboundWebhook;
+  try {
+    if (hookSecret) {
+      const wh = new Webhook(hookSecret.replace(/^v1,/, ""));
+      payload = wh.verify(raw, {
+        "webhook-id": req.headers.get("svix-id") ?? req.headers.get("webhook-id") ?? "",
+        "webhook-timestamp": req.headers.get("svix-timestamp") ?? req.headers.get("webhook-timestamp") ?? "",
+        "webhook-signature": req.headers.get("svix-signature") ?? req.headers.get("webhook-signature") ?? "",
+      }) as InboundWebhook;
+    } else {
+      console.warn("[forward-inbound-email] RESEND_WEBHOOK_SECRET non configuré : signature non vérifiée.");
+      payload = JSON.parse(raw) as InboundWebhook;
+    }
+  } catch (err) {
+    console.error("[forward-inbound-email] signature invalide :", err);
+    return new Response(JSON.stringify({ error: "signature invalide" }), { status: 401 });
+  }
+
+  // On ignore proprement tout autre événement Resend.
+  if (payload.type !== "email.received") {
+    return new Response(JSON.stringify({ ignored: payload.type }), { status: 200 });
+  }
+
+  // Inerte tant qu'aucune adresse de redirection n'est configurée.
+  if (forwardTo.length === 0) {
+    console.warn("[forward-inbound-email] RESEND_EMAIL_RECEIVED_FORWARD vide : aucune redirection.");
+    return new Response(JSON.stringify({ ignored: "no-forward-address" }), { status: 200 });
+  }
+
+  const emailId = payload.data.email_id;
+  const authHeaders = { Authorization: `Bearer ${RESEND_API_KEY}` };
+
+  // 1) Corps complet (HTML auto-suffisant : images inline embarquées en data URI).
+  const bodyRes = await fetch(
+    `https://api.resend.com/emails/receiving/${emailId}?html_format=data_uri`,
+    { headers: authHeaders },
+  );
+  if (!bodyRes.ok) {
+    console.error("[forward-inbound-email] échec récupération du mail :", bodyRes.status, await bodyRes.text());
+    return new Response(JSON.stringify({ error: "récupération du mail échouée" }), { status: 500 });
+  }
+  const received = (await bodyRes.json()) as ReceivedEmail;
+
+  // 2) Pièces jointes (download_url signés).
+  const attRes = await fetch(
+    `https://api.resend.com/emails/receiving/${emailId}/attachments`,
+    { headers: authHeaders },
+  );
+  let metas: InboundAttachmentMeta[] = [];
+  if (attRes.ok) {
+    const json = (await attRes.json()) as { data?: InboundAttachmentMeta[] };
+    metas = json.data ?? [];
+  } else {
+    console.warn("[forward-inbound-email] liste des pièces jointes indisponible :", attRes.status);
+  }
+  const { keep, skipped } = selectAttachments(metas, MAX_ATTACHMENTS_BYTES);
+
+  // 3) Téléchargement + encodage base64 des pièces jointes conservées.
+  const attachments: OutboundAttachment[] = [];
+  for (const a of keep) {
+    if (!a.download_url) {
+      skipped.push(a.filename);
+      continue;
+    }
+    const dl = await fetch(a.download_url);
+    if (!dl.ok) {
+      skipped.push(a.filename);
+      continue;
+    }
+    const bytes = new Uint8Array(await dl.arrayBuffer());
+    attachments.push({ filename: a.filename, content: encodeBase64(bytes), content_type: a.content_type });
+  }
+
+  // 4) Recomposition + envoi.
+  const email = buildForwardEmail({
+    received,
+    forwardTo,
+    resendFrom: RESEND_FROM,
+    attachments,
+    skippedAttachments: skipped,
+  });
+  const sendRes = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { ...authHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify(email),
+  });
+  if (!sendRes.ok) {
+    console.error("[forward-inbound-email] échec d'envoi Resend :", sendRes.status, await sendRes.text());
+    return new Response(JSON.stringify({ error: "échec de l'envoi" }), { status: 500 });
+  }
+
+  return new Response(JSON.stringify({ forwarded: forwardTo.length }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});
+```
+
+- [ ] **Step 2: Vérifier que le fichier type-check sans erreur**
+
+Run: `deno check supabase/functions/forward-inbound-email/index.ts`
+Expected: aucune erreur de type (sortie vide / `Check ...`).
+
+- [ ] **Step 3: Désactiver la vérification JWT pour cette fonction**
+
+Modifier `supabase/config.toml` — ajouter à la fin :
+
+```toml
+
+# Webhook Resend `email.received` : appelé par Resend (signature Svix), pas par un
+# utilisateur → pas de JWT à vérifier.
+[functions.forward-inbound-email]
+verify_jwt = false
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/functions/forward-inbound-email/index.ts supabase/config.toml
+git commit -m "feat(inbound-email): edge function webhook email.received"
+```
+
+---
+
+## Task 3: Câblage configuration & secrets (`.env.example`, `Makefile`)
+
+**Files:**
+- Modify: `.env.example`
+- Modify: `Makefile:46-50` (cible `supabase-secrets-email`)
+
+**Interfaces:**
+- Consumes : rien (config).
+- Produces : variables d'environnement `RESEND_EMAIL_RECEIVED_FORWARD` et `RESEND_WEBHOOK_SECRET` disponibles pour la fonction une fois `make supabase-secrets-email` exécuté.
+
+- [ ] **Step 1: Documenter les nouveaux secrets dans `.env.example`**
+
+Dans `.env.example`, remplacer le bloc Resend existant (lignes 18-21) :
+
+```
+# Fallback e-mail (Resend) — secrets de l'Edge Function (à mettre dans .env.local
+# puis `make supabase-secrets-email`). Domaine expéditeur à vérifier dans Resend.
+#   RESEND_API_KEY=re_xxx
+#   RESEND_FROM=Éphéméride <no-reply@ephemeride.app>
+```
+
+par :
+
+```
+# E-mail (Resend) — secrets de l'Edge Function (à mettre dans .env.local puis
+# `make supabase-secrets-email`). Domaine expéditeur à vérifier dans Resend.
+#   RESEND_API_KEY=re_xxx
+#   RESEND_FROM=Éphéméride <no-reply@ephemeride.app>
+# Redirection des mails entrants (webhook Resend email.received → ces adresses,
+# séparées par des virgules). Vide = aucune redirection.
+#   RESEND_EMAIL_RECEIVED_FORWARD=leny.bernard@gmail.com
+# Signing secret du webhook Resend (Resend → Webhooks → endpoint email.received).
+#   RESEND_WEBHOOK_SECRET=whsec_xxx
+```
+
+- [ ] **Step 2: Pousser les nouveaux secrets via le Makefile**
+
+Dans `Makefile`, remplacer la cible `supabase-secrets-email` (lignes 44-50) :
+
+```makefile
+# Configure les secrets Resend pour le fallback e-mail (valeurs depuis .env.local).
+# RESEND_FROM doit utiliser un domaine expéditeur vérifié dans Resend.
+supabase-secrets-email:
+	npx supabase secrets set \
+		RESEND_API_KEY="$(RESEND_API_KEY)" \
+		RESEND_FROM="$(RESEND_FROM)" \
+		SITE_URL="$(NEXT_PUBLIC_SITE_URL)"
+```
+
+par :
+
+```makefile
+# Configure les secrets Resend (e-mails sortants + redirection des mails entrants).
+# RESEND_FROM doit utiliser un domaine expéditeur vérifié dans Resend.
+supabase-secrets-email:
+	npx supabase secrets set \
+		RESEND_API_KEY="$(RESEND_API_KEY)" \
+		RESEND_FROM="$(RESEND_FROM)" \
+		SITE_URL="$(NEXT_PUBLIC_SITE_URL)" \
+		RESEND_EMAIL_RECEIVED_FORWARD="$(RESEND_EMAIL_RECEIVED_FORWARD)" \
+		RESEND_WEBHOOK_SECRET="$(RESEND_WEBHOOK_SECRET)"
+```
+
+- [ ] **Step 3: Vérifier que le Makefile parse toujours**
+
+Run: `make -n supabase-secrets-email`
+Expected: affiche la commande `npx supabase secrets set ...` avec les cinq variables (les valeurs vides si absentes de `.env.local`), sans erreur de syntaxe Make.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example Makefile
+git commit -m "chore(inbound-email): secrets redirection mails entrants Resend"
+```
+
+---
+
+## Task 4: Déploiement & configuration Resend (manuel)
+
+**Files:** aucun (étape opérationnelle).
+
+**Interfaces:**
+- Consumes : la fonction et les secrets des tasks précédentes.
+- Produces : webhook `email.received` actif côté Resend, fonction déployée.
+
+- [ ] **Step 1: Renseigner les valeurs dans `.env.local`**
+
+Ajouter dans `.env.local` (non versionné) :
+
+```
+RESEND_EMAIL_RECEIVED_FORWARD=leny.bernard@gmail.com
+RESEND_WEBHOOK_SECRET=
+```
+
+(`RESEND_WEBHOOK_SECRET` sera rempli au Step 4, après création du webhook côté Resend.)
+
+- [ ] **Step 2: Déployer la fonction**
+
+Run: `make deploy-fn FN=forward-inbound-email`
+Expected: déploiement réussi ; noter l'URL `https://<project-ref>.supabase.co/functions/v1/forward-inbound-email`.
+
+- [ ] **Step 3: Créer le webhook côté Resend**
+
+Dans le dashboard Resend → Webhooks → Add Endpoint :
+- URL : l'URL de la fonction (Step 2).
+- Événement : `email.received`.
+- Copier le **Signing Secret** affiché (format `whsec_...`).
+
+- [ ] **Step 4: Renseigner le secret et pousser la config**
+
+Coller le Signing Secret dans `.env.local` (`RESEND_WEBHOOK_SECRET=whsec_...`), puis :
+
+Run: `make supabase-secrets-email`
+Expected: `npx supabase secrets set` confirme la mise à jour des secrets.
+
+- [ ] **Step 5: Test de bout en bout**
+
+Envoyer un mail (avec une pièce jointe) à une adresse du domaine inbound Resend.
+Expected : réception du mail redirigé sur `leny.bernard@gmail.com`, avec le bandeau « Redirigé via Éphéméride », le sujet d'origine, le corps, la pièce jointe, et un `reply_to` pointant vers l'expéditeur d'origine. En cas d'échec, consulter les logs : `npx supabase functions logs forward-inbound-email`.
+
+---
+
+## Self-Review
+
+- **Couverture spec :** Edge Function (Task 2) ✓ ; signature Svix (Task 2) ✓ ; filtre `email.received` (Task 2) ✓ ; garde de config (Task 2) ✓ ; recomposition from/to/reply_to/subject/bandeau (Task 1) ✓ ; pièces jointes complètes + budget taille (Tasks 1+2) ✓ ; échec d'envoi → 500 (Task 2) ✓ ; `.env.example` + Makefile (Task 3) ✓ ; déploiement + webhook Resend (Task 4) ✓ ; tests unitaires (Task 1) ✓. Le point « à confirmer » de la spec (format payload + livraison des PJ) est désormais résolu et figé dans les contraintes globales.
+- **Placeholders :** aucun TODO/TBD ; tout le code est complet.
+- **Cohérence des types :** `InboundAttachmentMeta`, `ReceivedEmail`, `OutboundAttachment`, `ForwardEmail` définis en Task 1 et consommés tels quels en Task 2 ; signatures `parseForwardAddresses`/`selectAttachments`/`buildForwardEmail` identiques entre définition et usage.

--- a/docs/superpowers/specs/2026-06-26-forward-inbound-email-design.md
+++ b/docs/superpowers/specs/2026-06-26-forward-inbound-email-design.md
@@ -1,0 +1,96 @@
+# Redirection des mails entrants Resend — Design
+
+Date : 2026-06-26
+Statut : validé (design)
+
+## Objectif
+
+Permettre de rediriger automatiquement les mails reçus sur le domaine Resend
+(`email.received`) vers une ou plusieurs adresses configurées via la variable
+d'environnement `RESEND_EMAIL_RECEIVED_FORWARD` (ex. `leny.bernard@gmail.com`).
+
+Resend ne fait pas de relais SMTP transparent : le webhook `email.received`
+livre le mail parsé, et c'est notre code qui recompose puis ré-émet un nouvel
+email via l'API Resend depuis le domaine vérifié (`ephemeride.link`).
+« Rediriger » = recomposer et ré-émettre.
+
+## Décisions
+
+- **Fidélité** : complète, pièces jointes incluses.
+- **Sécurité** : vérification de la signature du webhook Resend (Svix) via un
+  secret `RESEND_WEBHOOK_SECRET`.
+- **Portée** : `RESEND_EMAIL_RECEIVED_FORWARD` peut contenir plusieurs adresses
+  séparées par des virgules ; le mail est redirigé vers chacune.
+
+## Architecture
+
+Nouvelle Edge Function Supabase `forward-inbound-email`
+(`supabase/functions/forward-inbound-email/index.ts`), runtime Deno, même style
+que `send-auth-email`. Son URL (`…/functions/v1/forward-inbound-email`) devient
+la cible du webhook `email.received` configuré côté Resend.
+
+```
+Mail entrant ──► Resend (inbound) ──webhook email.received──► forward-inbound-email
+                                                                  │ 1. vérifie signature Svix
+                                                                  │ 2. recompose le mail
+                                                                  └─► POST api.resend.com/emails ──► boîte(s) cible(s)
+```
+
+## Composants (responsabilités isolées)
+
+1. **Vérification de signature** — via la lib `standardwebhooks` (déjà utilisée
+   par `send-auth-email`), secret `RESEND_WEBHOOK_SECRET`. Signature invalide → `401`.
+2. **Filtre d'événement** — si `type !== "email.received"` → `200` (no-op : on
+   ignore proprement les autres events que Resend pourrait envoyer).
+3. **Garde de configuration** — si `RESEND_EMAIL_RECEIVED_FORWARD` est absent →
+   `200` + `console.warn`. La fonction reste inerte tant que le secret n'est pas
+   défini (pas d'échec dur).
+4. **Recomposition** — construit le nouvel email :
+   - `from` : `RESEND_FROM` (domaine vérifié), nom d'affichage rappelant
+     l'expéditeur d'origine, ex. `"Jean Dupont (via Éphéméride) <bonjour@ephemeride.link>"`.
+   - `to` : liste issue de `RESEND_EMAIL_RECEIVED_FORWARD` (split sur `,`, trim,
+     filtrage des entrées vides).
+   - `reply_to` : expéditeur d'origine → répondre renvoie bien à la bonne personne.
+   - `subject` : sujet d'origine, inchangé.
+   - corps `html`/`text` : corps d'origine, précédé d'un petit bandeau
+     « Redirigé — de X, à l'origine vers Y ».
+   - `attachments` : pièces jointes du mail entrant, ré-encodées en base64 pour
+     l'API d'envoi Resend.
+5. **Envoi** — `POST https://api.resend.com/emails` avec `Authorization: Bearer
+   RESEND_API_KEY`.
+
+## Gestion d'erreurs / cas limites
+
+- Échec d'envoi Resend → réponse `500` (Resend retentera le webhook).
+- Pièces jointes : Resend plafonne à ~40 Mo par message. Si dépassement, on omet
+  les PJ trop lourdes et on le signale dans le bandeau, plutôt que de faire
+  échouer toute la redirection.
+- Boucle de mail : la redirection part vers une adresse externe (Gmail…), pas
+  vers le domaine inbound — pas de boucle attendue. Pas de détection de boucle
+  spécifique dans cette version.
+
+## À confirmer en implémentation
+
+- Format exact du payload de l'event `email.received` (noms de champs :
+  `from`, `to`, `subject`, `html`, `text`, `headers`, `attachments`, etc.).
+- Mode de livraison des pièces jointes par Resend (base64 inline dans le payload
+  vs URL à télécharger puis ré-encoder en base64).
+
+Ces deux points seront calés sur la documentation Resend au moment d'écrire le
+code.
+
+## Configuration & déploiement
+
+- `.env.example` : ajout de `RESEND_EMAIL_RECEIVED_FORWARD` et
+  `RESEND_WEBHOOK_SECRET` (commentés, comme les autres secrets Resend).
+- `Makefile` : la cible `supabase-secrets-email` pousse aussi ces deux secrets ;
+  déploiement via `make deploy-fn FN=forward-inbound-email`.
+- Côté Resend : créer le webhook `email.received` pointant vers l'URL de la
+  fonction, et récupérer le signing secret pour `RESEND_WEBHOOK_SECRET`.
+
+## Tests
+
+- Test unitaire Deno sur la logique pure de recomposition (payload d'exemple →
+  objet d'envoi : `from`/`to`/`reply_to`/`subject`/`attachments`).
+- Test manuel : fonctionnalité de test de webhook de Resend (ou `curl` avec
+  payload + signature) vers la fonction déployée.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -4,3 +4,8 @@ project_id = "kgjvfuzdnbvgxkbndwfr"
 # par un utilisateur → pas de JWT à vérifier.
 [functions.send-auth-email]
 verify_jwt = false
+
+# Webhook Resend `email.received` : appelé par Resend (signature Svix), pas par un
+# utilisateur → pas de JWT à vérifier.
+[functions.forward-inbound-email]
+verify_jwt = false

--- a/supabase/functions/forward-inbound-email/forward.test.ts
+++ b/supabase/functions/forward-inbound-email/forward.test.ts
@@ -1,0 +1,111 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  bareAddress,
+  buildForwardEmail,
+  buildFrom,
+  parseForwardAddresses,
+  selectAttachments,
+  senderName,
+} from "./forward.ts";
+
+Deno.test("parseForwardAddresses : sépare, trim, ignore les vides", () => {
+  assertEquals(parseForwardAddresses("a@x.com, b@y.com ,, c@z.com"), [
+    "a@x.com",
+    "b@y.com",
+    "c@z.com",
+  ]);
+  assertEquals(parseForwardAddresses(undefined), []);
+  assertEquals(parseForwardAddresses(""), []);
+});
+
+Deno.test("bareAddress : extrait l'adresse e-mail", () => {
+  assertEquals(bareAddress("Jean Dupont <jean@x.com>"), "jean@x.com");
+  assertEquals(bareAddress("jean@x.com"), "jean@x.com");
+});
+
+Deno.test("senderName : nom d'affichage, sinon adresse", () => {
+  assertEquals(senderName("Jean Dupont <jean@x.com>"), "Jean Dupont");
+  assertEquals(senderName('"Jean Dupont" <jean@x.com>'), "Jean Dupont");
+  assertEquals(senderName("jean@x.com"), "jean@x.com");
+});
+
+Deno.test("buildFrom : nom d'origine + domaine vérifié", () => {
+  assertEquals(
+    buildFrom("Éphéméride <bonjour@ephemeride.link>", "Jean Dupont <jean@x.com>"),
+    "Jean Dupont (via Éphéméride) <bonjour@ephemeride.link>",
+  );
+});
+
+Deno.test("selectAttachments : ignore inline et hors budget", () => {
+  const metas = [
+    { id: "1", filename: "inline.png", content_type: "image/png", content_disposition: "inline", size: 10 },
+    { id: "2", filename: "doc.pdf", content_type: "application/pdf", content_disposition: "attachment", size: 100 },
+    { id: "3", filename: "big.zip", content_type: "application/zip", content_disposition: "attachment", size: 1000 },
+  ];
+  const { keep, skipped } = selectAttachments(metas, 500);
+  assertEquals(keep.map((a) => a.filename), ["doc.pdf"]);
+  assertEquals(skipped, ["big.zip"]);
+});
+
+Deno.test("buildForwardEmail : compose from/to/reply_to/subject + bandeau", () => {
+  const out = buildForwardEmail({
+    received: {
+      id: "e1",
+      from: "Jean Dupont <jean@x.com>",
+      to: ["contact@ephemeride.link"],
+      subject: "Bonjour",
+      html: "<p>Salut</p>",
+      text: "Salut",
+    },
+    forwardTo: ["leny.bernard@gmail.com"],
+    resendFrom: "Éphéméride <bonjour@ephemeride.link>",
+    attachments: [{ filename: "doc.pdf", content: "QUJD", content_type: "application/pdf" }],
+    skippedAttachments: [],
+  });
+  assertEquals(out.from, "Jean Dupont (via Éphéméride) <bonjour@ephemeride.link>");
+  assertEquals(out.to, ["leny.bernard@gmail.com"]);
+  assertEquals(out.reply_to, "jean@x.com");
+  assertEquals(out.subject, "Bonjour");
+  assertEquals(out.attachments?.length, 1);
+  assertEquals(out.html?.includes("Redirigé via Éphéméride"), true);
+  assertEquals(out.html?.includes("<p>Salut</p>"), true);
+  assertEquals(out.text?.includes("Salut"), true);
+});
+
+Deno.test("buildForwardEmail : échappe le HTML injecté dans le bandeau", () => {
+  const out = buildForwardEmail({
+    received: {
+      id: "e3",
+      from: "<script>@x.com",
+      to: ["contact@ephemeride.link"],
+      subject: "XSS",
+      html: "<p>Salut</p>",
+    },
+    forwardTo: ["leny.bernard@gmail.com"],
+    resendFrom: "Éphéméride <bonjour@ephemeride.link>",
+    attachments: [],
+    skippedAttachments: ["<img src=x>.zip"],
+  });
+  // Le markup injecté via le From d'origine ne doit pas apparaître littéralement.
+  assertEquals(out.html?.includes("<script>"), false);
+  assertEquals(out.html?.includes("&lt;script&gt;"), true);
+  // Le nom de fichier skipped est échappé dans le skippedLine.
+  assertEquals(out.html?.includes("<img src=x>"), false);
+  assertEquals(out.html?.includes("&lt;img src=x&gt;"), true);
+  // Le corps HTML d'origine reste transmis tel quel.
+  assertEquals(out.html?.includes("<p>Salut</p>"), true);
+});
+
+Deno.test("buildForwardEmail : corps minimal si ni html ni text", () => {
+  const out = buildForwardEmail({
+    received: { id: "e2", from: "jean@x.com", to: ["c@ephemeride.link"], subject: "Vide" },
+    forwardTo: ["leny.bernard@gmail.com"],
+    resendFrom: "Éphéméride <bonjour@ephemeride.link>",
+    attachments: [],
+    skippedAttachments: ["gros.zip"],
+  });
+  assertEquals(out.html, undefined);
+  assertEquals(out.text?.includes("(message sans contenu)"), true);
+  assertEquals(out.text?.includes("gros.zip"), true);
+  assertEquals(out.attachments, undefined);
+});

--- a/supabase/functions/forward-inbound-email/forward.ts
+++ b/supabase/functions/forward-inbound-email/forward.ts
@@ -1,0 +1,134 @@
+// Logique pure de recomposition d'un mail entrant Resend vers une redirection.
+// Aucune dépendance réseau ici → testable unitairement avec `deno test`.
+
+export interface InboundAttachmentMeta {
+  id: string;
+  filename: string;
+  content_type: string;
+  content_disposition: string; // "inline" | "attachment"
+  content_id?: string;
+  size?: number;
+  download_url?: string;
+}
+
+export interface ReceivedEmail {
+  id: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  reply_to?: string[];
+}
+
+export interface OutboundAttachment {
+  filename: string;
+  content: string; // base64
+  content_type?: string;
+}
+
+export interface ForwardEmail {
+  from: string;
+  to: string[];
+  reply_to: string;
+  subject: string;
+  html?: string;
+  text?: string;
+  attachments?: OutboundAttachment[];
+}
+
+// "a@x.com, b@y.com" -> ["a@x.com", "b@y.com"]
+export function parseForwardAddresses(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+// "Jean Dupont <jean@x.com>" -> "jean@x.com" ; "jean@x.com" -> "jean@x.com"
+export function bareAddress(addr: string): string {
+  const m = addr.match(/<([^>]+)>/);
+  return (m ? m[1] : addr).trim();
+}
+
+// "Jean Dupont <jean@x.com>" -> "Jean Dupont" ; "jean@x.com" -> "jean@x.com"
+export function senderName(from: string): string {
+  const m = from.match(/^\s*"?([^"<]*?)"?\s*<[^>]+>\s*$/);
+  const name = m && m[1] ? m[1].trim() : "";
+  return name || bareAddress(from);
+}
+
+// from d'envoi : nom de l'expéditeur d'origine, adresse de notre domaine vérifié.
+export function buildFrom(resendFrom: string, originalFrom: string): string {
+  return `${senderName(originalFrom)} (via Éphéméride) <${bareAddress(resendFrom)}>`;
+}
+
+// Garde les pièces jointes "réelles" (non inline) tant que le budget n'est pas
+// dépassé ; renvoie aussi les noms ignorés pour les signaler dans le bandeau.
+export function selectAttachments(
+  metas: InboundAttachmentMeta[],
+  maxTotalBytes: number,
+): { keep: InboundAttachmentMeta[]; skipped: string[] } {
+  const keep: InboundAttachmentMeta[] = [];
+  const skipped: string[] = [];
+  let total = 0;
+  for (const a of metas) {
+    if (a.content_disposition === "inline") continue; // déjà embarquée dans le HTML (data_uri)
+    const size = a.size ?? 0;
+    if (total + size > maxTotalBytes) {
+      skipped.push(a.filename);
+      continue;
+    }
+    total += size;
+    keep.push(a);
+  }
+  return { keep, skipped };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function bannerHtml(originalFrom: string, originalTo: string[], skipped: string[]): string {
+  const skippedLine = skipped.length
+    ? `<br/>Pièces jointes trop volumineuses, non incluses : ${skipped.map(escapeHtml).join(", ")}.`
+    : "";
+  return `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#64748b;border-left:3px solid #ED9873;padding:8px 12px;margin:0 0 16px;background:#faf3ec;">
+  Redirigé via Éphéméride — de <strong>${escapeHtml(originalFrom)}</strong>, à l'origine vers ${originalTo.map(escapeHtml).join(", ")}.${skippedLine}
+</div>`;
+}
+
+function bannerText(originalFrom: string, originalTo: string[], skipped: string[]): string {
+  const skippedLine = skipped.length
+    ? `\nPièces jointes trop volumineuses, non incluses : ${skipped.join(", ")}.`
+    : "";
+  return `Redirigé via Éphéméride — de ${originalFrom}, à l'origine vers ${originalTo.join(", ")}.${skippedLine}\n\n`;
+}
+
+export function buildForwardEmail(params: {
+  received: ReceivedEmail;
+  forwardTo: string[];
+  resendFrom: string;
+  attachments: OutboundAttachment[];
+  skippedAttachments: string[];
+}): ForwardEmail {
+  const { received, forwardTo, resendFrom, attachments, skippedAttachments } = params;
+  const to = received.to ?? [];
+  const out: ForwardEmail = {
+    from: buildFrom(resendFrom, received.from),
+    to: forwardTo,
+    reply_to: bareAddress(received.from),
+    subject: received.subject ?? "(sans objet)",
+  };
+  if (received.html != null) {
+    out.html = bannerHtml(received.from, to, skippedAttachments) + received.html;
+  }
+  if (received.text != null) {
+    out.text = bannerText(received.from, to, skippedAttachments) + received.text;
+  }
+  // Si ni html ni text, garantir un corps minimal.
+  if (out.html == null && out.text == null) {
+    out.text = bannerText(received.from, to, skippedAttachments) + "(message sans contenu)";
+  }
+  if (attachments.length > 0) out.attachments = attachments;
+  return out;
+}

--- a/supabase/functions/forward-inbound-email/index.ts
+++ b/supabase/functions/forward-inbound-email/index.ts
@@ -1,0 +1,149 @@
+// Webhook Resend `email.received` : redirige les mails entrants vers la/les
+// adresse(s) de RESEND_EMAIL_RECEIVED_FORWARD.
+//
+// Resend ne livre que des métadonnées dans le webhook : on récupère le corps via
+// l'API Receiving puis les pièces jointes via l'API Attachments, et on ré-émet un
+// nouveau mail via l'API d'envoi depuis notre domaine vérifié.
+//
+// Configuration (Resend → Webhooks → ajouter un endpoint sur `email.received`) :
+//   - pointer vers cette fonction,
+//   - copier le "Signing Secret" dans le secret `RESEND_WEBHOOK_SECRET`.
+// Déploiement : `make deploy-fn FN=forward-inbound-email`
+//
+// Secrets : RESEND_API_KEY (requis), RESEND_FROM, RESEND_EMAIL_RECEIVED_FORWARD,
+//           RESEND_WEBHOOK_SECRET.
+
+import { Webhook } from "npm:standardwebhooks@1.0.0";
+import { encodeBase64 } from "jsr:@std/encoding@1/base64";
+import {
+  buildForwardEmail,
+  type InboundAttachmentMeta,
+  type OutboundAttachment,
+  parseForwardAddresses,
+  type ReceivedEmail,
+  selectAttachments,
+} from "./forward.ts";
+
+const DEFAULT_FROM = "Éphéméride <bonjour@ephemeride.link>";
+// Budget sur octets BRUTS. Marge sous la limite ~40 Mo de Resend : le base64 gonfle d'environ 33 % et les images inline (data-URI) embarquées dans le HTML ne sont pas comptées ici.
+const MAX_ATTACHMENTS_BYTES = 20 * 1024 * 1024;
+
+interface InboundWebhook {
+  type: string;
+  data?: { email_id?: string };
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+
+  const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
+  if (!RESEND_API_KEY) {
+    return new Response(JSON.stringify({ error: "RESEND_API_KEY manquant" }), { status: 500 });
+  }
+  const RESEND_FROM = Deno.env.get("RESEND_FROM") ?? DEFAULT_FROM;
+  const forwardTo = parseForwardAddresses(Deno.env.get("RESEND_EMAIL_RECEIVED_FORWARD"));
+  const hookSecret = Deno.env.get("RESEND_WEBHOOK_SECRET");
+
+  const raw = await req.text();
+
+  // Vérifie la signature Svix émise par Resend (si le secret est configuré).
+  let payload: InboundWebhook;
+  try {
+    if (hookSecret) {
+      const wh = new Webhook(hookSecret.replace(/^v1,/, ""));
+      payload = wh.verify(raw, {
+        "webhook-id": req.headers.get("svix-id") ?? req.headers.get("webhook-id") ?? "",
+        "webhook-timestamp": req.headers.get("svix-timestamp") ?? req.headers.get("webhook-timestamp") ?? "",
+        "webhook-signature": req.headers.get("svix-signature") ?? req.headers.get("webhook-signature") ?? "",
+      }) as InboundWebhook;
+    } else {
+      console.warn("[forward-inbound-email] RESEND_WEBHOOK_SECRET non configuré : signature non vérifiée.");
+      payload = JSON.parse(raw) as InboundWebhook;
+    }
+  } catch (err) {
+    console.error("[forward-inbound-email] signature invalide :", err);
+    return new Response(JSON.stringify({ error: "signature invalide" }), { status: 401 });
+  }
+
+  // On ignore proprement tout autre événement Resend.
+  if (payload.type !== "email.received") {
+    return new Response(JSON.stringify({ ignored: payload.type }), { status: 200 });
+  }
+
+  // Inerte tant qu'aucune adresse de redirection n'est configurée.
+  if (forwardTo.length === 0) {
+    console.warn("[forward-inbound-email] RESEND_EMAIL_RECEIVED_FORWARD vide : aucune redirection.");
+    return new Response(JSON.stringify({ ignored: "no-forward-address" }), { status: 200 });
+  }
+
+  const emailId = payload.data?.email_id;
+  if (!emailId) {
+    console.error("[forward-inbound-email] payload email.received sans email_id :", raw.slice(0, 500));
+    return new Response(JSON.stringify({ error: "email_id manquant" }), { status: 400 });
+  }
+  const authHeaders = { Authorization: `Bearer ${RESEND_API_KEY}` };
+
+  // 1) Corps complet (HTML auto-suffisant : images inline embarquées en data URI).
+  const bodyRes = await fetch(
+    `https://api.resend.com/emails/receiving/${emailId}?html_format=data_uri`,
+    { headers: authHeaders },
+  );
+  if (!bodyRes.ok) {
+    console.error("[forward-inbound-email] échec récupération du mail :", bodyRes.status, await bodyRes.text());
+    return new Response(JSON.stringify({ error: "récupération du mail échouée" }), { status: 500 });
+  }
+  const received = (await bodyRes.json()) as ReceivedEmail;
+
+  // 2) Pièces jointes (download_url signés).
+  const attRes = await fetch(
+    `https://api.resend.com/emails/receiving/${emailId}/attachments`,
+    { headers: authHeaders },
+  );
+  let metas: InboundAttachmentMeta[] = [];
+  if (attRes.ok) {
+    const json = (await attRes.json()) as { data?: InboundAttachmentMeta[] };
+    metas = json.data ?? [];
+  } else {
+    console.warn("[forward-inbound-email] liste des pièces jointes indisponible :", attRes.status);
+  }
+  const { keep, skipped } = selectAttachments(metas, MAX_ATTACHMENTS_BYTES);
+
+  // 3) Téléchargement + encodage base64 des pièces jointes conservées.
+  const attachments: OutboundAttachment[] = [];
+  for (const a of keep) {
+    if (!a.download_url) {
+      skipped.push(a.filename);
+      continue;
+    }
+    const dl = await fetch(a.download_url);
+    if (!dl.ok) {
+      skipped.push(a.filename);
+      continue;
+    }
+    const bytes = new Uint8Array(await dl.arrayBuffer());
+    attachments.push({ filename: a.filename, content: encodeBase64(bytes), content_type: a.content_type });
+  }
+
+  // 4) Recomposition + envoi.
+  const email = buildForwardEmail({
+    received,
+    forwardTo,
+    resendFrom: RESEND_FROM,
+    attachments,
+    skippedAttachments: skipped,
+  });
+  const sendRes = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { ...authHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify(email),
+  });
+  if (!sendRes.ok) {
+    console.error("[forward-inbound-email] échec d'envoi Resend :", sendRes.status, await sendRes.text());
+    return new Response(JSON.stringify({ error: "échec de l'envoi" }), { status: 500 });
+  }
+
+  return new Response(JSON.stringify({ forwarded: forwardTo.length }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Objectif

Rediriger automatiquement les e-mails **reçus** sur le domaine Resend vers une ou plusieurs adresses configurées (`RESEND_EMAIL_RECEIVED_FORWARD`), via une Edge Function Supabase déclenchée par le webhook `email.received`.

## Comment ça marche

Le webhook `email.received` de Resend ne transmet que des **métadonnées**. La fonction [`forward-inbound-email`](supabase/functions/forward-inbound-email/index.ts) :

1. vérifie la signature Svix (`RESEND_WEBHOOK_SECRET`) ;
2. récupère le corps complet (`GET /emails/receiving/{id}?html_format=data_uri`) ;
3. récupère les pièces jointes (`GET /emails/receiving/{id}/attachments`, `download_url` signés), les télécharge et les ré-encode en base64 ;
4. **ré-émet** un nouveau message depuis le domaine vérifié (`RESEND_FROM`), avec `reply-to` vers l'expéditeur d'origine et un bandeau « Redirigé via Éphéméride ».

La fonction reste **inerte** tant que `RESEND_EMAIL_RECEIVED_FORWARD` est vide.

## Détails

- Architecture : logique pure de recomposition dans `forward.ts` (testée), orchestration réseau dans `index.ts`.
- Sécurité : signature Svix vérifiée ; valeurs externes (expéditeur, noms de PJ) échappées en HTML dans le bandeau.
- Robustesse : garde sur `email_id` manquant (400) ; budget pièces jointes prudent (20 Mo bruts) sous la limite ~40 Mo de Resend ; échec de récupération du corps ou d'envoi → 500 (retry Resend) ; PJ trop lourdes/indisponibles omises et signalées.
- `verify_jwt = false` (le webhook ne porte pas de JWT Supabase).
- Secrets câblés (`.env.example`, `Makefile supabase-secrets-email`).
- Documentation README : section « Redirection des e-mails entrants (Resend) ».

## Tests

`deno test supabase/functions/forward-inbound-email/forward.test.ts` → 8/8 ✅ · `deno check` clean.

## Étapes manuelles restantes (déploiement)

1. `make deploy-fn FN=forward-inbound-email` → noter l'URL.
2. Resend → Webhooks → Add Endpoint : URL + événement `email.received`, copier le *Signing Secret*.
3. Renseigner `RESEND_EMAIL_RECEIVED_FORWARD` et `RESEND_WEBHOOK_SECRET` dans `.env.local`, puis `make supabase-secrets-email`.
